### PR TITLE
Add mock build feature

### DIFF
--- a/SafeAuthenticator.Android/NativeLibrary.targets
+++ b/SafeAuthenticator.Android/NativeLibrary.targets
@@ -1,0 +1,18 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Choose>
+        <When Condition="$(DefineConstants.Contains(SAFE_AUTH_MOCK))">
+            <PropertyGroup>
+                <NativeLibType>mock</NativeLibType>
+            </PropertyGroup>
+        </When>
+        <Otherwise>
+            <PropertyGroup>
+                <NativeLibType>non-mock</NativeLibType>
+            </PropertyGroup>
+        </Otherwise>
+    </Choose>
+    <ItemGroup>
+        <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\armeabi-v7a\libsafe_authenticator.so" />
+        <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\x86\libsafe_authenticator.so" />
+    </ItemGroup>
+</Project>

--- a/SafeAuthenticator.Android/SafeAuthenticator.Android.csproj
+++ b/SafeAuthenticator.Android/SafeAuthenticator.Android.csproj
@@ -28,7 +28,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
@@ -52,6 +52,8 @@
     <AotAssemblies>false</AotAssemblies>
     <EnableLLVM>false</EnableLLVM>
     <BundleAssemblies>false</BundleAssemblies>
+    <DefineConstants>
+    </DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Java.Interop" />
@@ -82,16 +84,17 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <AndroidNativeLibrary Include="lib\armeabi-v7a\libsafe_authenticator.so" />
-    <AndroidAsset Include="..\SafeAuthenticator\crust.config">
-      <Link>Assets\crust.config</Link>
-    </AndroidAsset>
+    <None Include="app.config" />
+    <None Include="NativeLibrary.targets">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="Properties\AndroidManifest.xml" />
     <AndroidAsset Include="..\SafeAuthenticator\log.toml">
       <Link>Assets\log.toml</Link>
     </AndroidAsset>
-    <None Include="app.config" />
-    <AndroidNativeLibrary Include="lib\x86\libsafe_authenticator.so" />
-    <None Include="Properties\AndroidManifest.xml" />
+    <AndroidAsset Include="..\SafeAuthenticator\crust.config">
+      <Link>Assets\crust.config</Link>
+    </AndroidAsset>
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\layout\Tabbar.axml" />
@@ -214,4 +217,5 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
   </Target>
+  <Import Project="NativeLibrary.targets" />
 </Project>

--- a/SafeAuthenticator.iOS/NativeLibrary.targets
+++ b/SafeAuthenticator.iOS/NativeLibrary.targets
@@ -1,0 +1,22 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Choose>
+    <When Condition="$(DefineConstants.Contains(SAFE_AUTH_MOCK))">
+      <PropertyGroup>
+        <NativeLibType>mock</NativeLibType>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <NativeLibType>non-mock</NativeLibType>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <NativeReference Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\libsafe_authenticator.a">
+      <Kind>Static</Kind>
+      <ForceLoad>True</ForceLoad>
+      <LinkerFlags>-lresolv</LinkerFlags>
+      <Frameworks>Security</Frameworks>
+    </NativeReference>
+  </ItemGroup>
+</Project>

--- a/SafeAuthenticator.iOS/SafeAuthenticator.iOS.csproj
+++ b/SafeAuthenticator.iOS/SafeAuthenticator.iOS.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
@@ -145,6 +146,7 @@
     <Compile Include="Helpers\PaddedEntryRenderer.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
+    <None Include="NativeLibrary.targets" />
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\profile_generic.png" />
@@ -192,14 +194,6 @@
     </ImageAsset>
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="Native References/libsafe_authenticator.a">
-      <Kind>Static</Kind>
-      <ForceLoad>True</ForceLoad>
-      <LinkerFlags>-lresolv</LinkerFlags>
-      <Frameworks>Security</Frameworks>
-    </NativeReference>
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Acr.Support">
       <Version>2.1.0</Version>
     </PackageReference>
@@ -237,4 +231,5 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
   </Target>
+  <Import Project="NativeLibrary.targets"/>
 </Project>

--- a/Tests/SafeAuth.Tests.Android/SafeAuth.Tests.Android.csproj
+++ b/Tests/SafeAuth.Tests.Android/SafeAuth.Tests.Android.csproj
@@ -81,8 +81,12 @@
     <AndroidResource Include="Resources\drawable-xxhdpi\icon.png" />
   </ItemGroup>
   <ItemGroup>
-    <AndroidNativeLibrary Include="lib\armeabi-v7a\libsafe_authenticator.so" />
-    <AndroidNativeLibrary Include="lib\x86\libsafe_authenticator.so" />
+    <AndroidNativeLibrary Include="..\..\SafeAuthenticator.Android\lib\mock\armeabi-v7a\libsafe_authenticator.so">
+      <Link>lib\armeabi-v7a\libsafe_authenticator.so</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="..\..\SafeAuthenticator.Android\lib\mock\x86\libsafe_authenticator.so">
+      <Link>lib\x86\libsafe_authenticator.so</Link>
+    </AndroidNativeLibrary>
     <None Include="Properties\AndroidManifest.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/SafeAuth.Tests.IOS/SafeAuth.Tests.IOS.csproj
+++ b/Tests/SafeAuth.Tests.IOS/SafeAuth.Tests.IOS.csproj
@@ -160,7 +160,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="Native References/libsafe_authenticator.a">
+    <NativeReference Include="..\..\SafeAuthenticator.iOS\lib\mock\libsafe_authenticator.a">
       <Kind>Static</Kind>
     </NativeReference>
   </ItemGroup>


### PR DESCRIPTION
**Changes**
- Add mock build option in SafeAuthenticator (Previously we were replacing the native libs and then building).
- Use `SAFE_AUTH_MOCK` flag to use mock native libs 
- Update cake build script to download and extract mock and non-mock native libs
- Update test projects to reflect the use of downloaded mock-native libs.