### PR TITLE
CakeScript: Use http download instead of curl

### DIFF
--- a/CakeScripts/NativeLibs.cake
+++ b/CakeScripts/NativeLibs.cake
@@ -87,16 +87,7 @@ Task("Download-Libs")
 
                 if (!FileExists(zipSavePath))
                 {
-                    CurlDownloadFiles(
-                        new[] {
-                                new Uri (zipDownloadUrl)
-                        },
-                        new CurlDownloadSettings
-                        {
-                            OutputPaths = new FilePath[] {
-                                    zipSavePath
-                            }
-                        });
+                    DownloadFile(zipDownloadUrl, File(zipSavePath));
                 }
                 else
                 {

--- a/CakeScripts/NativeLibs.cake
+++ b/CakeScripts/NativeLibs.cake
@@ -1,4 +1,3 @@
-#addin Cake.Curl
 using System.Linq;
 
 var ANDROID_X86 = "android-x86";


### PR DESCRIPTION
- Use http download instead of using curl for downloading required libs from S3
- **Cake.Curl** requires curl to installed by default