### PR TITLE
Provide appropriate error message

### DIFF
--- a/SafeAuthenticator.Android/Properties/AndroidManifest.xml
+++ b/SafeAuthenticator.Android/Properties/AndroidManifest.xml
@@ -2,5 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="net.maidsafe.SafeAuthenticator" android:versionName="0.1" android:installLocation="auto" android:versionCode="1">
 	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
 	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<application android:label="@string/app_name" android:icon="@drawable/app_icon"></application>
 </manifest>

--- a/SafeAuthenticator/Helpers/Utilities.cs
+++ b/SafeAuthenticator/Helpers/Utilities.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Xamarin.Essentials;
 
 namespace SafeAuthenticator.Helpers {
   internal static class Utilities {
@@ -37,16 +38,17 @@ namespace SafeAuthenticator.Helpers {
     {
       switch (error.ErrorCode)
       {
-        case -2000:            
-        return ("Please update your IP address");
+        case -2000:
+        var current = Connectivity.NetworkAccess;
+        return current != NetworkAccess.Internet? "Internet connection not available" : "Please update your IP address" ;
         case -101:            
-        return ("Secret is invalid");
+        return "Secret is invalid";
         case -3:            
-        return ("Password is invalid");
+        return "Password is invalid";
         case -116:            
-        return ("Invalid invitation token");
+        return "Invalid invitation token";
         case -102:            
-        return ("Secret already exists");
+        return "Secret already exists";
         default:
         return error.Message;
       }            

--- a/SafeAuthenticator/Helpers/Utilities.cs
+++ b/SafeAuthenticator/Helpers/Utilities.cs
@@ -40,15 +40,17 @@ namespace SafeAuthenticator.Helpers {
       {
         case -2000:
         var current = Connectivity.NetworkAccess;
-        return current != NetworkAccess.Internet? "Internet connection not available" : "Please update your IP address" ;
+        return current != NetworkAccess.Internet? "No internet connection" : "Could not connect to the SAFE Network";
         case -101:            
-        return "Secret is invalid";
+        return "Account does not exist";
         case -3:            
-        return "Password is invalid";
-        case -116:            
-        return "Invalid invitation token";
+        return "Incorrect password";
         case -102:            
-        return "Secret already exists";
+        return "Account already exists";
+        case -116:            
+        return "Invalid invitation";
+        case -117:
+        return "Invitation already claimed";
         default:
         return error.Message;
       }            

--- a/SafeAuthenticator/Helpers/Utilities.cs
+++ b/SafeAuthenticator/Helpers/Utilities.cs
@@ -34,7 +34,7 @@ namespace SafeAuthenticator.Helpers {
       return (calc, percentage, Strength);
     }
 
-    internal static string HandleErrorMessage(FfiException error)
+    internal static string GetErrorMessage(FfiException error)
     {
       switch (error.ErrorCode)
       {

--- a/SafeAuthenticator/Helpers/Utilities.cs
+++ b/SafeAuthenticator/Helpers/Utilities.cs
@@ -1,5 +1,6 @@
 ﻿using Hexasoft.Zxcvbn;
 using SafeAuthenticator.Models;
+using SafeAuthenticator.Native;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,6 +31,25 @@ namespace SafeAuthenticator.Helpers {
       else if (calc >= AppConstants.AccStrengthSomeWhatSecure) Strength = "SECURE";
       double percentage = Math.Round(Math.Min((calc / 16) * 100, 100));
       return (calc, percentage, Strength);
+    }
+
+    internal static string HandleErrorMessage(FfiException error)
+    {
+      switch (error.ErrorCode)
+      {
+        case -2000:            
+        return ("Please update your IP address");
+        case -101:            
+        return ("Secret is invalid");
+        case -3:            
+        return ("Password is invalid");
+        case -116:            
+        return ("Invalid invitation token");
+        case -102:            
+        return ("Secret already exists");
+        default:
+        return error.Message;
+      }            
     }
         #region Encoding Extensions
 

--- a/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
+++ b/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
@@ -89,7 +89,7 @@ namespace SafeAuthenticator.ViewModels {
         }
       }
       catch(FfiException ex) {
-        var errorMessage = Utilities.HandleErrorMessage(ex);
+        var errorMessage = Utilities.GetErrorMessage(ex);
         await Application.Current.MainPage.DisplayAlert("Error", errorMessage, "OK");
       }
       catch (Exception ex) {

--- a/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
+++ b/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using Acr.UserDialogs;
 using SafeAuthenticator.Helpers;
+using SafeAuthenticator.Native;
 using Xamarin.Forms;
 
 namespace SafeAuthenticator.ViewModels {
@@ -86,7 +87,12 @@ namespace SafeAuthenticator.ViewModels {
         await Authenticator.CreateAccountAsync(AcctSecret, AcctPassword, Invitation);
         MessagingCenter.Send(this, MessengerConstants.NavHomePage);
         }
-      } catch (Exception ex) {
+      }
+      catch(FfiException ex) {
+        var errorMessage = Utilities.HandleErrorMessage(ex);
+        await Application.Current.MainPage.DisplayAlert("Error", errorMessage, "OK");
+      }
+      catch (Exception ex) {
         await Application.Current.MainPage.DisplayAlert("Error", $"Create Acct Failed: {ex.Message}", "OK");
       }
     }

--- a/SafeAuthenticator/ViewModels/LoginViewModel.cs
+++ b/SafeAuthenticator/ViewModels/LoginViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows.Input;
 using SafeAuthenticator.Helpers;
+using SafeAuthenticator.Native;
 using Xamarin.Forms;
 
 namespace SafeAuthenticator.ViewModels {
@@ -69,7 +70,13 @@ namespace SafeAuthenticator.ViewModels {
       try {
         await Authenticator.LoginAsync(AcctSecret, AcctPassword);
         MessagingCenter.Send(this, MessengerConstants.NavHomePage);
-      } catch (Exception ex) {
+      }
+      catch(FfiException ex) {
+        var errorMessage = Utilities.HandleErrorMessage(ex);
+        await Application.Current.MainPage.DisplayAlert("Error", errorMessage, "OK");
+        IsUiEnabled = true;
+      }
+      catch (Exception ex) {
         await Application.Current.MainPage.DisplayAlert("Error", $"Log in Failed: {ex.Message}", "OK");
         IsUiEnabled = true;
       }

--- a/SafeAuthenticator/ViewModels/LoginViewModel.cs
+++ b/SafeAuthenticator/ViewModels/LoginViewModel.cs
@@ -74,7 +74,7 @@ namespace SafeAuthenticator.ViewModels {
         }    
       }
       catch(FfiException ex) {
-        var errorMessage = Utilities.HandleErrorMessage(ex);
+        var errorMessage = Utilities.GetErrorMessage(ex);
         await Application.Current.MainPage.DisplayAlert("Error", errorMessage, "OK");
       }
       catch (Exception ex) {

--- a/SafeAuthenticator/ViewModels/LoginViewModel.cs
+++ b/SafeAuthenticator/ViewModels/LoginViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Input;
+using Acr.UserDialogs;
 using SafeAuthenticator.Helpers;
 using SafeAuthenticator.Native;
 using Xamarin.Forms;
@@ -66,19 +67,18 @@ namespace SafeAuthenticator.ViewModels {
     }
 
     private async void OnLogin() {
-      IsUiEnabled = false;
       try {
+        using (UserDialogs.Instance.Loading("Loading")) {
         await Authenticator.LoginAsync(AcctSecret, AcctPassword);
         MessagingCenter.Send(this, MessengerConstants.NavHomePage);
+        }    
       }
       catch(FfiException ex) {
         var errorMessage = Utilities.HandleErrorMessage(ex);
         await Application.Current.MainPage.DisplayAlert("Error", errorMessage, "OK");
-        IsUiEnabled = true;
       }
       catch (Exception ex) {
         await Application.Current.MainPage.DisplayAlert("Error", $"Log in Failed: {ex.Message}", "OK");
-        IsUiEnabled = true;
       }
     }
   }

--- a/SafeAuthenticator/Views/CreateAcctPage.xaml
+++ b/SafeAuthenticator/Views/CreateAcctPage.xaml
@@ -66,8 +66,6 @@
                                  VerticalOptions="Fill" HorizontalOptions="Fill" />
                 </Grid>
                 <StackLayout Margin="20" HeightRequest="{StaticResource ButtonHeightRequest}" VerticalOptions="Center">
-                    <ActivityIndicator IsRunning="True"
-                                       IsVisible="{Binding IsUiEnabled, Converter={StaticResource InverseBooleanConverter}}" />
                     <Button Text="Create Account"
                             TextColor="White" Command="{Binding CreateAcctCommand}" IsVisible="{Binding IsUiEnabled}" />
                 </StackLayout>

--- a/SafeAuthenticator/Views/LoginPage.xaml
+++ b/SafeAuthenticator/Views/LoginPage.xaml
@@ -70,8 +70,6 @@
                 </Grid>
                 <StackLayout Margin="20,20,20,35" HeightRequest="{StaticResource ButtonHeightRequest}"
                              VerticalOptions="Center">
-                    <ActivityIndicator IsRunning="True"
-                                       IsVisible="{Binding IsUiEnabled, Converter={StaticResource InverseBooleanConverter}}" />
                     <Button Text="Login"
                             TextColor="White" Command="{Binding LoginCommand}" IsVisible="{Binding IsUiEnabled}" />
                 </StackLayout>


### PR DESCRIPTION
fixes [#25](https://github.com/maidsafe/safe-authenticator-mobile/issues/25)
display appropriate error messages instead of displaying the error code