### PR TITLE
Update registered applist manually before sending authentication response

### DIFF
--- a/SafeAuthenticator/Helpers/Constants.cs
+++ b/SafeAuthenticator/Helpers/Constants.cs
@@ -9,6 +9,7 @@
 
         internal static readonly string AppName = "SAFE Authenticator";
         internal static readonly string IsTutorialComplete = "IsTutorialComplete";
+        internal static readonly string AppOwnContainer = "App's own Container";
 
         // Authentication PopupState
         internal static readonly string None = "None";

--- a/SafeAuthenticator/Services/AuthService.cs
+++ b/SafeAuthenticator/Services/AuthService.cs
@@ -190,18 +190,6 @@ namespace SafeAuthenticator.Services
                 }
                 else
                 {
-                    // var requestPage = new RequestDetailPage(decodeResult);
-                    // requestPage.CompleteRequest += async (s, e) =>
-                    // {
-                    //    var args = e as ResponseEventArgs;
-                    //    if (args.Response)
-                    //    {
-                    //        MessagingCenter.Send(this, MessengerConstants.RefreshHomePage, decodeResult);
-                    //    }
-
-                    // await SendResponseBack(encodedUri, decodeResult, args.Response);
-                    // };
-
                     MessagingCenter.Send(this, MessengerConstants.NavHomePage);
                     var requestPage = new RequestDetailPage(encodedUri, decodeResult);
                     await Application.Current.MainPage.Navigation.PushPopupAsync(requestPage);

--- a/SafeAuthenticator/Services/AuthService.cs
+++ b/SafeAuthenticator/Services/AuthService.cs
@@ -194,6 +194,11 @@ namespace SafeAuthenticator.Services
                     requestPage.CompleteRequest += async (s, e) =>
                     {
                         var args = e as ResponseEventArgs;
+                        if (args.Response)
+                        {
+                            MessagingCenter.Send(this, MessengerConstants.RefreshHomePage, decodeResult);
+                        }
+
                         await SendResponseBack(encodedUri, decodeResult, args.Response);
                     };
 

--- a/SafeAuthenticator/ViewModels/HomeViewModel.cs
+++ b/SafeAuthenticator/ViewModels/HomeViewModel.cs
@@ -4,6 +4,7 @@ using System.Windows.Input;
 using SafeAuthenticator.Helpers;
 using SafeAuthenticator.Models;
 using SafeAuthenticator.Native;
+using SafeAuthenticator.Services;
 using Xamarin.Forms;
 
 namespace SafeAuthenticator.ViewModels
@@ -51,11 +52,85 @@ namespace SafeAuthenticator.ViewModels
             Device.BeginInvokeOnMainThread(OnRefreshAccounts);
 
             MessagingCenter.Subscribe<AppInfoViewModel>(this, MessengerConstants.RefreshHomePage, (sender) => { OnRefreshAccounts(); });
+            MessagingCenter.Subscribe<AuthService, IpcReq>(this, MessengerConstants.RefreshHomePage, (sender, decodeResult) =>
+            {
+                var decodedType = decodeResult.GetType();
+
+                // Authentication Request
+                if (decodedType == typeof(AuthIpcReq))
+                {
+                    var ipcReq = (AuthIpcReq)decodeResult;
+                    var app = new RegisteredAppModel(ipcReq.AuthReq.App, ipcReq.AuthReq.Containers);
+                    var isAppContainerPresent = ipcReq.AuthReq.AppContainer;
+                    var appOwnContainer = new ContainerPermissionsModel()
+                    {
+                        ContainerName = "App's own Container",
+                        Access = new PermissionSetModel
+                        {
+                            Read = true,
+                            Insert = true,
+                            Update = true,
+                            Delete = true,
+                            ManagePermissions = true
+                        }
+                    };
+
+                    // Add app to registeredAppList if not present
+                    if (!Apps.Contains(app))
+                    {
+                        // Adding app's own container if present
+                        if (isAppContainerPresent)
+                        {
+                            app.Containers.Add(appOwnContainer);
+                            app.Containers.ReplaceRange(app.Containers.OrderBy(a => a.ContainerName).ToObservableRangeCollection());
+                        }
+                        var registeredApps = Apps;
+                        registeredApps.Add(app);
+                        registeredApps = registeredApps.OrderBy(a => a.AppName).ToObservableRangeCollection();
+                        Apps.ReplaceRange(registeredApps);
+                    }
+
+                    // If app already exists in registeredAppList, and app's own container is requested but not previously added
+                    else if (isAppContainerPresent)
+                    {
+                        var registeredAppsItem = Apps.FirstOrDefault(a => a.AppId == app.AppId);
+                        var container = registeredAppsItem.Containers.FirstOrDefault(a => a.ContainerName == "App's own Container");
+                        if (container == null)
+                        {
+                            registeredAppsItem.Containers.Add(appOwnContainer);
+                            registeredAppsItem.Containers.ReplaceRange(registeredAppsItem.Containers.OrderBy(a => a.ContainerName).ToObservableRangeCollection());
+                        }
+                    }
+                }
+
+                // Container Request
+                else if (decodedType == typeof(ContainersIpcReq))
+                {
+                    var ipcReq = (ContainersIpcReq)decodeResult;
+                    var app = new RegisteredAppModel(ipcReq.ContainersReq.App, ipcReq.ContainersReq.Containers);
+
+                    var registeredAppsItem = Apps.FirstOrDefault(a => a.AppId == app.AppId);
+                    foreach (var container in app.Containers)
+                    {
+                        var containersItem = registeredAppsItem.Containers.FirstOrDefault(a => a.ContainerName == container.ContainerName);
+
+                        // Add new containers
+                        if (containersItem == null)
+                            registeredAppsItem.Containers.Add(container);
+
+                        // Update permission set of existing containers
+                        else
+                            containersItem.Access = container.Access;
+                    }
+                    registeredAppsItem.Containers.ReplaceRange(registeredAppsItem.Containers.OrderBy(a => a.ContainerName).ToObservableRangeCollection());
+                }
+            });
         }
 
         ~HomeViewModel()
         {
             MessagingCenter.Unsubscribe<AppInfoViewModel>(this, MessengerConstants.RefreshHomePage);
+            MessagingCenter.Unsubscribe<AuthService, RegisteredAppModel>(this, MessengerConstants.RefreshHomePage);
         }
 
         private void OnAccountSelected(RegisteredAppModel appModelInfo)


### PR DESCRIPTION
fixes [#9](https://github.com/maidsafe/safe-authenticator-mobile/issues/9)

Cater to the following scenarios:
- Authentication request: 
    - When an authentication request is sent by an app which has not been registered yet (or previously revoked), all containers and their respective permissions which are requested are added.
    - When an authentication request is sent by an app which has already been registered, the request isn't capable of adding new containers or modifying the permissions of existing containers 
    - App's own container can be added at any time by an authentication request
- Container request: 
    - New containers may be added and permissions for the existing container may be modified by any container request   
    - App's own container cannot be added or modified by a container request
