### PR TITLE
Handle delay after authentication request popup

### DIFF
--- a/SafeAuthenticator/App.xaml.cs
+++ b/SafeAuthenticator/App.xaml.cs
@@ -11,8 +11,6 @@ namespace SafeAuthenticator
 {
     public partial class App : Application
     {
-        internal const string AppName = "SAFE Authenticator";
-        private const string IsFirstLaunch = "IsFirstLaunch";
         private static volatile bool _isBackgrounded;
 
         private AuthService Service => DependencyService.Get<AuthService>();
@@ -54,9 +52,9 @@ namespace SafeAuthenticator
 
         private Page NewStartupPage()
         {
-            if (!Current.Properties.ContainsKey(IsFirstLaunch))
+            if (!Current.Properties.ContainsKey(Constants.IsFirstLaunch))
             {
-                Current.Properties[IsFirstLaunch] = true;
+                Current.Properties[Constants.IsFirstLaunch] = true;
                 return new TutorialPage();
             }
             else

--- a/SafeAuthenticator/Helpers/AppConstants.cs
+++ b/SafeAuthenticator/Helpers/AppConstants.cs
@@ -17,8 +17,5 @@ namespace SafeAuthenticator.Helpers
         public const ulong SymKeyLen = 32;
         public const ulong SymNonceLen = 24;
         public const ulong XorNameLen = 32;
-        public const int AccStrengthVeryWeak = 4;
-        public const int AccStrengthWeak = 8;
-        public const int AccStrengthSomeWhatSecure = 10;
     }
 }

--- a/SafeAuthenticator/Helpers/Constants.cs
+++ b/SafeAuthenticator/Helpers/Constants.cs
@@ -1,11 +1,11 @@
 ﻿namespace SafeAuthenticator.Helpers
 {
-    static class Constants
+    internal static class Constants
     {
         // StringStrength
-        public const int AccStrengthVeryWeak = 4;
-        public const int AccStrengthWeak = 8;
-        public const int AccStrengthSomeWhatSecure = 10;
+        internal const int AccStrengthVeryWeak = 4;
+        internal const int AccStrengthWeak = 8;
+        internal const int AccStrengthSomeWhatSecure = 10;
 
         internal static readonly string AppName = "SAFE Authenticator";
         internal static readonly string IsFirstLaunch = "IsFirstLaunch";

--- a/SafeAuthenticator/Helpers/Constants.cs
+++ b/SafeAuthenticator/Helpers/Constants.cs
@@ -1,0 +1,18 @@
+﻿namespace SafeAuthenticator.Helpers
+{
+    static class Constants
+    {
+        // StringStrength
+        public const int AccStrengthVeryWeak = 4;
+        public const int AccStrengthWeak = 8;
+        public const int AccStrengthSomeWhatSecure = 10;
+
+        internal static readonly string AppName = "SAFE Authenticator";
+        internal static readonly string IsFirstLaunch = "IsFirstLaunch";
+
+        // Authentication PopupState
+        internal static readonly string None = "None";
+        internal static readonly string Error = "Error";
+        internal static readonly string Loading = "Loading";
+    }
+}

--- a/SafeAuthenticator/Helpers/Utilities.cs
+++ b/SafeAuthenticator/Helpers/Utilities.cs
@@ -40,19 +40,19 @@ namespace SafeAuthenticator.Helpers
 
             var result = _estimator.EstimateStrength(data);
             strengthIndicator.Guesses = Math.Log(result.Guesses) / Math.Log(10);
-            if (strengthIndicator.Guesses < AppConstants.AccStrengthVeryWeak)
+            if (strengthIndicator.Guesses < Constants.AccStrengthVeryWeak)
             {
                 strengthIndicator.Strength = "VERY_WEAK";
             }
-            else if (strengthIndicator.Guesses < AppConstants.AccStrengthWeak)
+            else if (strengthIndicator.Guesses < Constants.AccStrengthWeak)
             {
                 strengthIndicator.Strength = "WEAK";
             }
-            else if (strengthIndicator.Guesses < AppConstants.AccStrengthSomeWhatSecure)
+            else if (strengthIndicator.Guesses < Constants.AccStrengthSomeWhatSecure)
             {
                 strengthIndicator.Strength = "SOMEWHAT_SECURE";
             }
-            else if (strengthIndicator.Guesses >= AppConstants.AccStrengthSomeWhatSecure)
+            else if (strengthIndicator.Guesses >= Constants.AccStrengthSomeWhatSecure)
             {
                 strengthIndicator.Strength = "SECURE";
             }

--- a/SafeAuthenticator/Services/AuthService.cs
+++ b/SafeAuthenticator/Services/AuthService.cs
@@ -190,8 +190,8 @@ namespace SafeAuthenticator.Services
                 }
                 else
                 {
-                    var requestPage = new RequestDetailPage(encodedUri, decodeResult);
                     MessagingCenter.Send(this, MessengerConstants.NavHomePage);
+                    var requestPage = new RequestDetailPage(encodedUri, decodeResult);
                     await Application.Current.MainPage.Navigation.PushPopupAsync(requestPage);
                 }
             }
@@ -206,44 +206,35 @@ namespace SafeAuthenticator.Services
             }
         }
 
-        internal async Task SendResponseBack(string encodedUri, IpcReq req, bool isGranted)
+        internal async Task<string> GetEncodedResponseAsync(IpcReq req, bool isGranted)
         {
-            string encodedRsp;
-            var formattedRsp = string.Empty;
+            string encodedRsp = string.Empty;
             var requestType = req.GetType();
             if (requestType == typeof(UnregisteredIpcReq))
             {
                 var uauthReq = req as UnregisteredIpcReq;
                 encodedRsp = await Authenticator.EncodeUnregisteredRespAsync(uauthReq.ReqId, isGranted);
-                var appIdFromUrl = UrlFormat.GetAppId(encodedUri);
-                formattedRsp = UrlFormat.Format(appIdFromUrl, encodedRsp, false);
             }
             else if (requestType == typeof(AuthIpcReq))
             {
                 var authReq = req as AuthIpcReq;
                 encodedRsp = await _authenticator.EncodeAuthRespAsync(authReq, isGranted);
-                formattedRsp = UrlFormat.Format(authReq?.AuthReq.App.Id, encodedRsp, false);
             }
             else if (requestType == typeof(ContainersIpcReq))
             {
                 var containerReq = req as ContainersIpcReq;
                 encodedRsp = await _authenticator.EncodeContainersRespAsync(containerReq, isGranted);
-                formattedRsp = UrlFormat.Format(containerReq?.ContainersReq.App.Id, encodedRsp, false);
             }
             else if (requestType == typeof(ShareMDataIpcReq))
             {
                 var mDataShareReq = req as ShareMDataIpcReq;
                 if (!isGranted)
                 {
-                    await Application.Current.MainPage.DisplayAlert("Error", "SharedMData request denied", "OK");
-                    return;
+                    throw new Exception("SharedMData request denied");
                 }
                 encodedRsp = await _authenticator.EncodeShareMdataRespAsync(mDataShareReq, isGranted);
-                formattedRsp = UrlFormat.Format(mDataShareReq?.ShareMDataReq.App.Id, encodedRsp, false);
             }
-
-            Debug.WriteLine($"Encoded Rsp to app: {formattedRsp}");
-            Device.BeginInvokeOnMainThread(() => { Device.OpenUri(new Uri(formattedRsp)); });
+            return encodedRsp;
         }
 
         private async Task<bool> HandleUnregisteredAppRequest(string encodedUri)

--- a/SafeAuthenticator/Services/AuthService.cs
+++ b/SafeAuthenticator/Services/AuthService.cs
@@ -190,13 +190,7 @@ namespace SafeAuthenticator.Services
                 }
                 else
                 {
-                    var requestPage = new RequestDetailPage(decodeResult);
-                    requestPage.CompleteRequest += async (s, e) =>
-                    {
-                        var args = e as ResponseEventArgs;
-                        await SendResponseBack(encodedUri, decodeResult, args.Response);
-                    };
-
+                    var requestPage = new RequestDetailPage(encodedUri, decodeResult);
                     MessagingCenter.Send(this, MessengerConstants.NavHomePage);
                     await Application.Current.MainPage.Navigation.PushPopupAsync(requestPage);
                 }
@@ -212,56 +206,44 @@ namespace SafeAuthenticator.Services
             }
         }
 
-        private async Task SendResponseBack(string encodedUri, IpcReq req, bool isGranted)
+        internal async Task SendResponseBack(string encodedUri, IpcReq req, bool isGranted)
         {
-            try
+            string encodedRsp;
+            var formattedRsp = string.Empty;
+            var requestType = req.GetType();
+            if (requestType == typeof(UnregisteredIpcReq))
             {
-                string encodedRsp;
-                var formattedRsp = string.Empty;
-                var requestType = req.GetType();
-                if (requestType == typeof(UnregisteredIpcReq))
+                var uauthReq = req as UnregisteredIpcReq;
+                encodedRsp = await Authenticator.EncodeUnregisteredRespAsync(uauthReq.ReqId, isGranted);
+                var appIdFromUrl = UrlFormat.GetAppId(encodedUri);
+                formattedRsp = UrlFormat.Format(appIdFromUrl, encodedRsp, false);
+            }
+            else if (requestType == typeof(AuthIpcReq))
+            {
+                var authReq = req as AuthIpcReq;
+                encodedRsp = await _authenticator.EncodeAuthRespAsync(authReq, isGranted);
+                formattedRsp = UrlFormat.Format(authReq?.AuthReq.App.Id, encodedRsp, false);
+            }
+            else if (requestType == typeof(ContainersIpcReq))
+            {
+                var containerReq = req as ContainersIpcReq;
+                encodedRsp = await _authenticator.EncodeContainersRespAsync(containerReq, isGranted);
+                formattedRsp = UrlFormat.Format(containerReq?.ContainersReq.App.Id, encodedRsp, false);
+            }
+            else if (requestType == typeof(ShareMDataIpcReq))
+            {
+                var mDataShareReq = req as ShareMDataIpcReq;
+                if (!isGranted)
                 {
-                    var uauthReq = req as UnregisteredIpcReq;
-                    encodedRsp = await Authenticator.EncodeUnregisteredRespAsync(uauthReq.ReqId, isGranted);
-                    var appIdFromUrl = UrlFormat.GetAppId(encodedUri);
-                    formattedRsp = UrlFormat.Format(appIdFromUrl, encodedRsp, false);
+                    await Application.Current.MainPage.DisplayAlert("Error", "SharedMData request denied", "OK");
+                    return;
                 }
-                else if (requestType == typeof(AuthIpcReq))
-                {
-                    var authReq = req as AuthIpcReq;
-                    encodedRsp = await _authenticator.EncodeAuthRespAsync(authReq, isGranted);
-                    formattedRsp = UrlFormat.Format(authReq?.AuthReq.App.Id, encodedRsp, false);
-                }
-                else if (requestType == typeof(ContainersIpcReq))
-                {
-                    var containerReq = req as ContainersIpcReq;
-                    encodedRsp = await _authenticator.EncodeContainersRespAsync(containerReq, isGranted);
-                    formattedRsp = UrlFormat.Format(containerReq?.ContainersReq.App.Id, encodedRsp, false);
-                }
-                else if (requestType == typeof(ShareMDataIpcReq))
-                {
-                    var mDataShareReq = req as ShareMDataIpcReq;
-                    if (!isGranted)
-                    {
-                        await Application.Current.MainPage.DisplayAlert("Error", "SharedMData request denied", "OK");
-                        return;
-                    }
-                    encodedRsp = await _authenticator.EncodeShareMdataRespAsync(mDataShareReq, isGranted);
-                    formattedRsp = UrlFormat.Format(mDataShareReq?.ShareMDataReq.App.Id, encodedRsp, false);
-                }
+                encodedRsp = await _authenticator.EncodeShareMdataRespAsync(mDataShareReq, isGranted);
+                formattedRsp = UrlFormat.Format(mDataShareReq?.ShareMDataReq.App.Id, encodedRsp, false);
+            }
 
-                Debug.WriteLine($"Encoded Rsp to app: {formattedRsp}");
-                Device.BeginInvokeOnMainThread(() => { Device.OpenUri(new Uri(formattedRsp)); });
-            }
-            catch (FfiException ex)
-            {
-                var errorMessage = Utilities.GetErrorMessage(ex);
-                await Application.Current.MainPage.DisplayAlert("Error", errorMessage, "OK");
-            }
-            catch (Exception ex)
-            {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
-            }
+            Debug.WriteLine($"Encoded Rsp to app: {formattedRsp}");
+            Device.BeginInvokeOnMainThread(() => { Device.OpenUri(new Uri(formattedRsp)); });
         }
 
         private async Task<bool> HandleUnregisteredAppRequest(string encodedUri)
@@ -270,13 +252,7 @@ namespace SafeAuthenticator.Services
             var udecodeResult = await Authenticator.UnRegisteredDecodeIpcMsgAsync(encodedReq);
             if (udecodeResult.GetType() == typeof(UnregisteredIpcReq))
             {
-                var requestPage = new RequestDetailPage(udecodeResult);
-                requestPage.CompleteRequest += async (s, e) =>
-                {
-                    var args = e as ResponseEventArgs;
-                    await SendResponseBack(encodedUri, udecodeResult, args.Response);
-                };
-
+                var requestPage = new RequestDetailPage(encodedUri, udecodeResult);
                 await Application.Current.MainPage.Navigation.PushPopupAsync(requestPage);
                 return true;
             }

--- a/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
+++ b/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
@@ -176,7 +176,7 @@ namespace SafeAuthenticator.ViewModels
                         await Task.Run(() =>
                         {
                             _locationStrength = Utilities.StrengthChecker(AcctSecret);
-                            if (_locationStrength.Guesses < AppConstants.AccStrengthWeak)
+                            if (_locationStrength.Guesses < Constants.AccStrengthWeak)
                             {
                                 AcctSecretErrorMsg = "Secret needs to be stronger";
                                 throw new InvalidOperationException();
@@ -217,7 +217,7 @@ namespace SafeAuthenticator.ViewModels
                 await Task.Run(() =>
                 {
                     _passwordStrength = Utilities.StrengthChecker(AcctPassword);
-                    if (_passwordStrength.Guesses < AppConstants.AccStrengthSomeWhatSecure)
+                    if (_passwordStrength.Guesses < Constants.AccStrengthSomeWhatSecure)
                     {
                         AcctPasswordErrorMsg = "Password needs to be stronger";
                         throw new InvalidOperationException();

--- a/SafeAuthenticator/ViewModels/RequestDetailViewModel.cs
+++ b/SafeAuthenticator/ViewModels/RequestDetailViewModel.cs
@@ -77,7 +77,7 @@ namespace SafeAuthenticator.ViewModels
             encodedRequest = encodedUri;
             decodedRequest = req;
 
-            PopupState = "none";
+            PopupState = Constants.None;
             SendResponseCommand = new Command<string>(OnSendResponse);
 
             if (requestType == typeof(UnregisteredIpcReq))
@@ -199,7 +199,7 @@ namespace SafeAuthenticator.ViewModels
             {
                 var response = sender == "ALLOW" ? true : false;
                 PopupLayoutHeight = minPopupHeight;
-                PopupState = "loading";
+                PopupState = Constants.Loading;
                 await Authenticator.SendResponseBack(encodedRequest, decodedRequest, response);
                 await PopupNavigation.Instance.PopAsync();
             }
@@ -208,13 +208,13 @@ namespace SafeAuthenticator.ViewModels
                 var errorMessage = Utilities.GetErrorMessage(ex);
                 PopupLayoutHeight = minPopupHeight;
                 ErrorMessage = errorMessage;
-                PopupState = "error";
+                PopupState = Constants.Error;
             }
             catch (Exception ex)
             {
                 PopupLayoutHeight = minPopupHeight;
                 ErrorMessage = ex.Message;
-                PopupState = "error";
+                PopupState = Constants.Error;
             }
         }
     }

--- a/SafeAuthenticator/ViewModels/RequestDetailViewModel.cs
+++ b/SafeAuthenticator/ViewModels/RequestDetailViewModel.cs
@@ -1,11 +1,15 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Windows.Input;
+using Rg.Plugins.Popup.Services;
 using SafeAuthenticator.Helpers;
 using SafeAuthenticator.Models;
 using SafeAuthenticator.Native;
+using Xamarin.Forms;
 
 namespace SafeAuthenticator.ViewModels
 {
-    public class RequestDetailViewModel : ObservableObject
+    internal class RequestDetailViewModel : BaseViewModel
     {
         public AppExchangeInfo AppInfo { get; set; }
 
@@ -29,15 +33,52 @@ namespace SafeAuthenticator.ViewModels
 
         public ObservableRangeCollection<MDataModel> MData { get; set; }
 
+        int minPopupHeight = 170;
+        int maxPopupHeight = 260;
+
+        private string _popupState;
+
+        public string PopupState
+        {
+            get => _popupState;
+            set => SetProperty(ref _popupState, value);
+        }
+
+        private int _popupLayoutHeight;
+
+        public int PopupLayoutHeight
+        {
+            get => _popupLayoutHeight;
+            set => SetProperty(ref _popupLayoutHeight, value);
+        }
+
+        private string _errorMessage;
+
+        public string ErrorMessage
+        {
+            get => _errorMessage;
+            set => SetProperty(ref _errorMessage, value);
+        }
+
+        private readonly string encodedRequest;
+        private readonly IpcReq decodedRequest;
+
         private readonly AuthIpcReq _authReq;
         private readonly ShareMDataIpcReq _shareMdReq;
         private readonly ContainersIpcReq _containerReq;
 
-        public RequestDetailViewModel(IpcReq req)
+        public ICommand SendResponseCommand { get; }
+
+        public RequestDetailViewModel(string encodedUri, IpcReq req)
         {
             Containers = new ObservableRangeCollection<ContainerPermissionsModel>();
             MData = new ObservableRangeCollection<MDataModel>();
             var requestType = req.GetType();
+            encodedRequest = encodedUri;
+            decodedRequest = req;
+
+            PopupState = "none";
+            SendResponseCommand = new Command<string>(OnSendResponse);
 
             if (requestType == typeof(UnregisteredIpcReq))
             {
@@ -63,6 +104,7 @@ namespace SafeAuthenticator.ViewModels
                 ProcessMDataRequestData();
                 SecondaryTitle = MData.Count > 0 ? "\nis requesting access to" : "\nis requesting access";
             }
+            PopupLayoutHeight = (Containers.Count == 0 && MData.Count == 0) ? minPopupHeight : maxPopupHeight;
         }
 
         private void ProcessAuthRequestData()
@@ -143,6 +185,36 @@ namespace SafeAuthenticator.ViewModels
             {
                 MData[i].MetaName = _shareMdReq.MetadataResponse[i].Name;
                 MData[i].MetaDescription = _shareMdReq.MetadataResponse[i].Description;
+            }
+        }
+
+        private async void OnSendResponse(string sender)
+        {
+            if (sender == "OK")
+            {
+                await PopupNavigation.Instance.PopAsync();
+                return;
+            }
+            try
+            {
+                var response = sender == "ALLOW" ? true : false;
+                PopupLayoutHeight = minPopupHeight;
+                PopupState = "loading";
+                await Authenticator.SendResponseBack(encodedRequest, decodedRequest, response);
+                await PopupNavigation.Instance.PopAsync();
+            }
+            catch (FfiException ex)
+            {
+                var errorMessage = Utilities.GetErrorMessage(ex);
+                PopupLayoutHeight = minPopupHeight;
+                ErrorMessage = errorMessage;
+                PopupState = "error";
+            }
+            catch (Exception ex)
+            {
+                PopupLayoutHeight = minPopupHeight;
+                ErrorMessage = ex.Message;
+                PopupState = "error";
             }
         }
     }

--- a/SafeAuthenticator/ViewModels/RequestDetailViewModel.cs
+++ b/SafeAuthenticator/ViewModels/RequestDetailViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Windows.Input;
 using Rg.Plugins.Popup.Services;
@@ -200,8 +201,11 @@ namespace SafeAuthenticator.ViewModels
                 var response = sender == "ALLOW" ? true : false;
                 PopupLayoutHeight = minPopupHeight;
                 PopupState = Constants.Loading;
-                await Authenticator.SendResponseBack(encodedRequest, decodedRequest, response);
+                var encodedRsp = await Authenticator.GetEncodedResponseAsync(decodedRequest, response);
                 await PopupNavigation.Instance.PopAsync();
+                var formattedRsp = UrlFormat.Format(AppId, encodedRsp, false);
+                Debug.WriteLine($"Encoded Rsp to app: {formattedRsp}");
+                Device.BeginInvokeOnMainThread(() => { Device.OpenUri(new Uri(formattedRsp)); });
             }
             catch (FfiException ex)
             {

--- a/SafeAuthenticator/Views/RequestDetailPage.xaml
+++ b/SafeAuthenticator/Views/RequestDetailPage.xaml
@@ -26,6 +26,7 @@
     <pages:PopupPage.Resources>
         <ResourceDictionary>
             <converters:InverseBooleanConverter x:Key="InverseBoolean" />
+            <Color x:Key="RedLightColor">#ffebeb</Color>
             <Style x:Key="H1Style" TargetType="Label">
                 <Setter Property="FontSize" Value="{StaticResource LargeSize}" />
                 <Setter Property="FontAttributes" Value="Bold" />
@@ -53,20 +54,7 @@
             <StackLayout x:Name="PopupLayout" 
                          Spacing="10"
                          Padding="16"
-                         HeightRequest="260">
-                <StackLayout.Triggers>
-                    <MultiTrigger TargetType="StackLayout">
-                        <MultiTrigger.Conditions>
-                            <BindingCondition
-                                Binding="{Binding Containers.Count, Converter={StaticResource IsCollectionEmptyConverter}}"
-                                Value="true" />
-                            <BindingCondition
-                                Binding="{Binding MData.Count, Converter={StaticResource IsCollectionEmptyConverter}}"
-                                Value="true" />
-                        </MultiTrigger.Conditions>
-                        <Setter Property="HeightRequest" Value="180" />
-                    </MultiTrigger>
-                </StackLayout.Triggers>
+                         HeightRequest="{Binding PopupLayoutHeight}">
 
                 <Grid HorizontalOptions="FillAndExpand">
                     <Grid.RowDefinitions>
@@ -106,12 +94,11 @@
                                  IsVisible="{Binding IsUnregisteredRequest, Converter={StaticResource InverseBoolean}}"/>
                 </Grid>
 
-                <StackLayout x:Name="AppDetailsStackLayout" 
+                <StackLayout x:Name="AppDetailsStackLayout"
                              VerticalOptions="Start" 
                              IsVisible="False" 
                              Margin="10,0">
-                    <Label Margin="0,0,0,15"
-                           Style="{StaticResource H2Style}">
+                    <Label Style="{StaticResource H2Style}">
                         <Label.FormattedText>
                             <FormattedString>
                                 <Span Text="Vendor&#10;"
@@ -127,126 +114,181 @@
                     </Label>
                 </StackLayout>
 
-                <Label VerticalOptions="CenterAndExpand" 
-                       HorizontalTextAlignment="Center"
-                       VerticalTextAlignment="Center"
-                       IsVisible="{Binding IsUnregisteredRequest}"
-                       Style="{StaticResource H2Style}"
-                       Text="An application is requesting access to read public content on the network"/>
+                <StackLayout IsVisible="False"
+                             VerticalOptions="CenterAndExpand">
+                    <StackLayout.Triggers>
+                        <DataTrigger TargetType="StackLayout"
+                                         Binding="{Binding PopupState}"
+                                         Value="none">
+                            <Setter Property="IsVisible" Value="True" />
+                        </DataTrigger>
+                    </StackLayout.Triggers>
+                    
+                        <Label HorizontalTextAlignment="Center"
+                               IsVisible="{Binding IsUnregisteredRequest}"
+                               FontSize="{StaticResource LargeSize}"
+                               Text="An application is requesting access to read public content on the network" />
 
-                <StackLayout IsVisible="False" 
-                             VerticalOptions="CenterAndExpand"
-                             x:Name="NoContainerTextLabel">
-                    <Label
-                        HorizontalTextAlignment="Center"
-                       Style="{StaticResource H2Style}"
-                       Text="No permissions requested"
-                       TextColor="{StaticResource GreySmokeMediumColor}"
-                       FontAttributes="Bold">
-                        <Label.Triggers>
-                            <DataTrigger TargetType="Label"
+                    <StackLayout x:Name="NoContainerTextLabel"
+                             IsVisible="False">
+                        <Label
+                            HorizontalTextAlignment="Center"
+                            Style="{StaticResource H2Style}"
+                            Text="No permissions requested"
+                            TextColor="{StaticResource GreySmokeMediumColor}"
+                            FontAttributes="Bold">
+                            <Label.Triggers>
+                                <DataTrigger TargetType="Label"
                                          Binding="{Binding IsContainerRequest}"
                                          Value="true">
-                                <Setter Property="Text" Value="No container permissions requested" />
-                            </DataTrigger>
-                        </Label.Triggers>
-                    </Label>
-                    
-                    <Frame HasShadow="False"
+                                    <Setter Property="Text" Value="No container permissions requested" />
+                                </DataTrigger>
+                            </Label.Triggers>
+                        </Label>
+
+                        <Frame HasShadow="False"
                        CornerRadius="4"
                        Padding="10"
                        BackgroundColor="{StaticResource GreySnowMediumColor}">
 
-                        <Label HorizontalTextAlignment="Center"
+                            <Label HorizontalTextAlignment="Center"
                                Style="{StaticResource H3Style}"
                                Text="The application will be able to to read data on the network"/>
-                    </Frame>
-                    <StackLayout.Triggers>
-                        <MultiTrigger TargetType="StackLayout">
-                            <MultiTrigger.Conditions>
-                                <BindingCondition
+                        </Frame>
+                        <StackLayout.Triggers>
+                            <MultiTrigger TargetType="StackLayout">
+                                <MultiTrigger.Conditions>
+                                    <BindingCondition
                                     Binding="{Binding Containers.Count, Converter={StaticResource IsCollectionEmptyConverter}}"
                                     Value="true" />
-                                <BindingCondition
+                                    <BindingCondition
                                     Binding="{Binding MData.Count, Converter={StaticResource IsCollectionEmptyConverter}}"
                                     Value="true" />
-                                <BindingCondition
+                                    <BindingCondition
                                     Binding="{Binding IsUnregisteredRequest}"
                                     Value="false" />
-                                <BindingCondition
+                                    <BindingCondition
                                     Binding="{Binding IsMDataRequest}"
                                     Value="false" />
-                            </MultiTrigger.Conditions>
-                            <Setter Property="IsVisible" Value="True"/>
-                        </MultiTrigger>
-                    </StackLayout.Triggers>
-                </StackLayout>
+                                </MultiTrigger.Conditions>
+                                <Setter Property="IsVisible" Value="True"/>
+                            </MultiTrigger>
+                        </StackLayout.Triggers>
+                    </StackLayout>
 
-                <ListView x:Name="ContainerPermissionListView"
+                    <ListView x:Name="ContainerPermissionListView"
                           HasUnevenRows="True"
                           SeparatorVisibility="None"
-                          VerticalOptions="FillAndExpand"
                           ItemsSource="{Binding Containers}"
                           IsVisible="False">
 
-                    <ListView.Behaviors>
-                        <behaviour:ListViewNoSelectionBehavior />
-                    </ListView.Behaviors>
+                        <ListView.Behaviors>
+                            <behaviour:ListViewNoSelectionBehavior />
+                        </ListView.Behaviors>
 
-                    <ListView.ItemTemplate>
-                        <DataTemplate>
-                            <controls:ContainerPermissionViewCell />
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <controls:ContainerPermissionViewCell />
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
 
-                    <ListView.Triggers>
-                        <MultiTrigger TargetType="ListView">
-                            <MultiTrigger.Conditions>
-                                <BindingCondition
+                        <ListView.Triggers>
+                            <MultiTrigger TargetType="ListView">
+                                <MultiTrigger.Conditions>
+                                    <BindingCondition
                                 Binding="{Binding Containers.Count, Converter={StaticResource IsCollectionEmptyConverter}}"
                                 Value="false" />
-                            </MultiTrigger.Conditions>
-                            <Setter Property="IsVisible" Value="True" />
-                        </MultiTrigger>
-                    </ListView.Triggers>
-                </ListView>
+                                </MultiTrigger.Conditions>
+                                <Setter Property="IsVisible" Value="True" />
+                            </MultiTrigger>
+                        </ListView.Triggers>
+                    </ListView>
 
-                <ListView x:Name="MDataPermissionListView"
+                    <ListView x:Name="MDataPermissionListView"
                           HasUnevenRows="True"
                           SeparatorVisibility="None"
                           ItemsSource="{Binding MData}"
                           IsVisible="False">
 
-                    <ListView.Behaviors>
-                        <behaviour:ListViewNoSelectionBehavior />
-                    </ListView.Behaviors>
+                        <ListView.Behaviors>
+                            <behaviour:ListViewNoSelectionBehavior />
+                        </ListView.Behaviors>
 
-                    <ListView.ItemTemplate>
-                        <DataTemplate>
-                            <controls:MDataPermissionViewCell />
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <controls:MDataPermissionViewCell />
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
 
-                    <ListView.Triggers>
-                        <MultiTrigger TargetType="ListView">
-                            <MultiTrigger.Conditions>
-                                <BindingCondition
+                        <ListView.Triggers>
+                            <MultiTrigger TargetType="ListView">
+                                <MultiTrigger.Conditions>
+                                    <BindingCondition
                                 Binding="{Binding MData.Count, Converter={StaticResource IsCollectionEmptyConverter}}"
                                 Value="false" />
-                            </MultiTrigger.Conditions>
-                            <Setter Property="IsVisible" Value="True" />
-                        </MultiTrigger>
-                    </ListView.Triggers>
-                </ListView>
+                                </MultiTrigger.Conditions>
+                                <Setter Property="IsVisible" Value="True" />
+                            </MultiTrigger>
+                        </ListView.Triggers>
+                    </ListView>
+                </StackLayout>
 
                 <StackLayout Orientation="Horizontal"
-                             VerticalOptions="EndAndExpand">
+                             IsVisible="False"
+                             HorizontalOptions="CenterAndExpand"
+                             VerticalOptions="CenterAndExpand">
+                    <StackLayout.Triggers>
+                        <DataTrigger TargetType="StackLayout"
+                                         Binding="{Binding PopupState}"
+                                         Value="loading">
+                            <Setter Property="IsVisible" Value="True" />
+                        </DataTrigger>
+                    </StackLayout.Triggers>
+
+                    <ActivityIndicator IsRunning="True"/>
+                    
+                    <Label Text="Authenticating Application..."
+                           FontSize="{StaticResource LargeSize}"
+                           VerticalTextAlignment="Center"/>
+                </StackLayout>
+
+                <Frame HasShadow="False"
+                       CornerRadius="4"
+                       Padding="10"
+                       BackgroundColor="{StaticResource RedLightColor}"
+                       IsVisible="False"                        
+                       VerticalOptions="CenterAndExpand">
+                    <Frame.Triggers>
+                        <DataTrigger TargetType="Frame"
+                                     Binding="{Binding PopupState}"
+                                     Value="error">
+                            <Setter Property="IsVisible" 
+                                    Value="True" />
+                        </DataTrigger>
+                    </Frame.Triggers>
+                    <Label Text="{Binding ErrorMessage}"
+                           TextColor="{StaticResource RedColor}"
+                           FontSize="{StaticResource LargeSize}"
+                           HorizontalTextAlignment="Center" />
+                </Frame>
+
+                <StackLayout Orientation="Horizontal"
+                             VerticalOptions="End"
+                             IsVisible="False">
+                    <StackLayout.Triggers>
+                        <DataTrigger TargetType="StackLayout"
+                                         Binding="{Binding PopupState}"
+                                         Value="none">
+                            <Setter Property="IsVisible" Value="True" />
+                        </DataTrigger>
+                    </StackLayout.Triggers>
 
                     <Button x:Name="DenyButton"
                             Text="DENY"
                             HorizontalOptions="EndAndExpand"
                             TextColor="{StaticResource PrimaryColor}"
-                            Clicked="Send_Response"
+                            Command="{Binding SendResponseCommand}" 
+                            CommandParameter="{Binding Source={x:Reference DenyButton}, Path=Text}"
                             Style="{StaticResource ButtonStyle}"
                             BackgroundColor="Transparent" />
 
@@ -254,9 +296,30 @@
                             Text="ALLOW"
                             HorizontalOptions="End"
                             BackgroundColor="{StaticResource PrimaryColor}"
-                            Clicked="Send_Response"
+                            Command="{Binding SendResponseCommand}"
+                            CommandParameter="{Binding Source={x:Reference AllowButton}, Path=Text}"
                             Style="{StaticResource ButtonStyle}" />
                 </StackLayout>
+
+                <Button x:Name="OkButton"
+                        Text="OK"
+                        VerticalOptions="End"
+                        HorizontalOptions="End"
+                        TextColor="{StaticResource PrimaryColor}"
+                        Command="{Binding SendResponseCommand}" 
+                        CommandParameter="{Binding Source={x:Reference OkButton}, Path=Text}"
+                        Style="{StaticResource ButtonStyle}"
+                        BackgroundColor="Transparent" 
+                        WidthRequest="50"
+                        IsVisible="False">
+                    <Button.Triggers>
+                        <DataTrigger TargetType="Button"
+                                         Binding="{Binding PopupState}"
+                                         Value="error">
+                            <Setter Property="IsVisible" Value="True" />
+                        </DataTrigger>
+                    </Button.Triggers>
+                </Button>
 
             </StackLayout>
         </Frame>

--- a/SafeAuthenticator/Views/RequestDetailPage.xaml
+++ b/SafeAuthenticator/Views/RequestDetailPage.xaml
@@ -119,7 +119,7 @@
                     <StackLayout.Triggers>
                         <DataTrigger TargetType="StackLayout"
                                          Binding="{Binding PopupState}"
-                                         Value="none">
+                                         Value="None">
                             <Setter Property="IsVisible" Value="True" />
                         </DataTrigger>
                     </StackLayout.Triggers>
@@ -240,7 +240,7 @@
                     <StackLayout.Triggers>
                         <DataTrigger TargetType="StackLayout"
                                          Binding="{Binding PopupState}"
-                                         Value="loading">
+                                         Value="Loading">
                             <Setter Property="IsVisible" Value="True" />
                         </DataTrigger>
                     </StackLayout.Triggers>
@@ -261,7 +261,7 @@
                     <Frame.Triggers>
                         <DataTrigger TargetType="Frame"
                                      Binding="{Binding PopupState}"
-                                     Value="error">
+                                     Value="Error">
                             <Setter Property="IsVisible" 
                                     Value="True" />
                         </DataTrigger>
@@ -278,7 +278,7 @@
                     <StackLayout.Triggers>
                         <DataTrigger TargetType="StackLayout"
                                          Binding="{Binding PopupState}"
-                                         Value="none">
+                                         Value="None">
                             <Setter Property="IsVisible" Value="True" />
                         </DataTrigger>
                     </StackLayout.Triggers>
@@ -315,7 +315,7 @@
                     <Button.Triggers>
                         <DataTrigger TargetType="Button"
                                          Binding="{Binding PopupState}"
-                                         Value="error">
+                                         Value="Error">
                             <Setter Property="IsVisible" Value="True" />
                         </DataTrigger>
                     </Button.Triggers>

--- a/SafeAuthenticator/Views/RequestDetailPage.xaml.cs
+++ b/SafeAuthenticator/Views/RequestDetailPage.xaml.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Rg.Plugins.Popup.Pages;
-using Rg.Plugins.Popup.Services;
-using SafeAuthenticator.Models;
+﻿using Rg.Plugins.Popup.Pages;
 using SafeAuthenticator.Native;
 using SafeAuthenticator.ViewModels;
 using Xamarin.Forms.Xaml;
@@ -11,11 +8,9 @@ namespace SafeAuthenticator.Views
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class RequestDetailPage : PopupPage
     {
-        public event EventHandler CompleteRequest;
-
         private readonly RequestDetailViewModel _viewModel;
 
-        public RequestDetailPage(IpcReq req)
+        public RequestDetailPage(string encodedUri, IpcReq req)
         {
             InitializeComponent();
 
@@ -23,26 +18,13 @@ namespace SafeAuthenticator.Views
             {
                 AppDetailsStackLayout.IsVisible = !AppDetailsStackLayout.IsVisible;
                 if (AppDetailsStackLayout.IsVisible)
-                    PopupLayout.HeightRequest += 85;
+                    PopupLayout.HeightRequest += 105;
                 else
-                    PopupLayout.HeightRequest -= 85;
+                    PopupLayout.HeightRequest -= 105;
             };
 
-            _viewModel = new RequestDetailViewModel(req);
+            _viewModel = new RequestDetailViewModel(encodedUri, req);
             BindingContext = _viewModel;
-        }
-
-        private void Send_Response(object sender, EventArgs e)
-        {
-            if (sender == AllowButton)
-            {
-                CompleteRequest?.Invoke(this, new ResponseEventArgs(true));
-            }
-            else if (sender == DenyButton)
-            {
-                CompleteRequest?.Invoke(this, new ResponseEventArgs(false));
-            }
-            PopupNavigation.Instance.PopAsync();
         }
     }
 }


### PR DESCRIPTION
fixes [#55](https://github.com/maidsafe/safe-authenticator-mobile/issues/55)
Handle the following scenarios in an authentication popup, 
- Displaying the popup with all the details of the requester app
After the user allow/deny the request
- Display a loading state 
after which the response is sent back to requester app, and in case we have an error
- Display the error message to the user