### PR TITLE
Add paste icon inside invitation token entry

### DIFF
--- a/SafeAuthenticator.Android/Helpers/MaterialEntryRenderer.cs
+++ b/SafeAuthenticator.Android/Helpers/MaterialEntryRenderer.cs
@@ -143,7 +143,8 @@ namespace SafeAuthenticator.Droid.Helpers
                      (e.PropertyName == Entry.FontSizeProperty.PropertyName))
                 SetFontAttributesSizeAndFamily();
             else if (e.PropertyName == MaterialEntry.ActivePlaceholderColorProperty.PropertyName ||
-                     e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
+                     e.PropertyName == Entry.PlaceholderColorProperty.PropertyName ||
+                     e.PropertyName == MaterialEntry.IsUnderlineTransparentProperty.PropertyName)
                 SetLabelAndUnderlineColor();
             else if (e.PropertyName == Entry.TextColorProperty.PropertyName)
                 SetTextColor();
@@ -186,8 +187,16 @@ namespace SafeAuthenticator.Droid.Helpers
 
         private void SetUnderlineColor(AColor color)
         {
-            var element = (ITintableBackgroundView)EditText;
-            element.SupportBackgroundTintList = ColorStateList.ValueOf(color);
+            if (Element.IsUnderlineTransparent)
+            {
+                var element = (ITintableBackgroundView)EditText;
+                element.SupportBackgroundTintList = ColorStateList.ValueOf(AColor.Transparent);
+            }
+            else
+            {
+                var element = (ITintableBackgroundView)EditText;
+                element.SupportBackgroundTintList = ColorStateList.ValueOf(color);
+            }
         }
 
         private void SetHintLabelActiveColor(AColor color)

--- a/SafeAuthenticator.Android/Helpers/MaterialEntryRenderer.cs
+++ b/SafeAuthenticator.Android/Helpers/MaterialEntryRenderer.cs
@@ -94,6 +94,9 @@ namespace SafeAuthenticator.Droid.Helpers
                 if (!string.IsNullOrWhiteSpace(Element.AutomationId))
                     EditText.ContentDescription = Element.AutomationId;
 
+                if (Element.IsUnderlineTransparent)
+                    Control.EditText.SetPadding(Control.PaddingLeft, Control.PaddingTop, Control.PaddingRight, 0);
+
                 _defaultTextColor = EditText.TextColors;
 
                 Focusable = true;

--- a/SafeAuthenticator.iOS/Helpers/MaterialEntryRenderer.cs
+++ b/SafeAuthenticator.iOS/Helpers/MaterialEntryRenderer.cs
@@ -200,6 +200,9 @@ namespace SafeAuthenticator.iOS.Helpers
 
         private CGColor GetUnderlineColorForState()
         {
+            if (Element.IsUnderlineTransparent)
+                return Color.Transparent.ToCGColor();
+
             if (_hasError)
                 return UIColor.Red.CGColor;
 

--- a/SafeAuthenticator.iOS/SafeAuthenticator.iOS.csproj
+++ b/SafeAuthenticator.iOS/SafeAuthenticator.iOS.csproj
@@ -87,7 +87,7 @@
     <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>iPhone Developer: Ashwin Kumar (QY457ZUAH2)</CodesignKey>
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
     <MtouchDebug>true</MtouchDebug>
     <MtouchFastDev>true</MtouchFastDev>
@@ -100,8 +100,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <MtouchExtraArgs>
     </MtouchExtraArgs>
-    <CodesignProvision>
-    </CodesignProvision>
+    <CodesignProvision>iOS App Dev 09/01/19</CodesignProvision>
     <MtouchNoSymbolStrip>false</MtouchNoSymbolStrip>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">

--- a/SafeAuthenticator.iOS/SafeAuthenticator.iOS.csproj
+++ b/SafeAuthenticator.iOS/SafeAuthenticator.iOS.csproj
@@ -87,7 +87,7 @@
     <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodesignKey>iPhone Developer: Ashwin Kumar (QY457ZUAH2)</CodesignKey>
+    <CodesignKey>iPhone Developer</CodesignKey>
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
     <MtouchDebug>true</MtouchDebug>
     <MtouchFastDev>true</MtouchFastDev>
@@ -100,7 +100,8 @@
     <PlatformTarget>x86</PlatformTarget>
     <MtouchExtraArgs>
     </MtouchExtraArgs>
-    <CodesignProvision>iOS App Dev 09/01/19</CodesignProvision>
+    <CodesignProvision>
+    </CodesignProvision>
     <MtouchNoSymbolStrip>false</MtouchNoSymbolStrip>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">

--- a/SafeAuthenticator/App.xaml
+++ b/SafeAuthenticator/App.xaml
@@ -16,7 +16,8 @@
             <Color x:Key="GreySmokeLightColor">#c2c1c1</Color>
             <Color x:Key="GreySmokeMediumColor">#8b8b8b</Color>
             <Color x:Key="GreySnowMediumColor">#e4e4e4</Color>
-            <Color x:Key="DefaultPlaceholderColor">#80000000</Color>
+            <Color x:Key="DefaultAndroidPlaceholderColor">#80000000</Color>
+            <Color x:Key="DefaultiOSPlaceholderColor">#a9a9a9</Color>
 
             <!-- CONVERTERS -->
             <converters:IsCollectionEmptyConverter x:Key="IsCollectionEmptyConverter" />
@@ -58,6 +59,11 @@
                         Android="18"
                         iOS="16" />
 
+            <OnPlatform x:Key="DefaultPlaceholderColor"
+                        x:TypeArguments="Color"         
+                        Android="{StaticResource DefaultAndroidPlaceholderColor}" 
+                        iOS="{StaticResource DefaultiOSPlaceholderColor}" />
+
             <!-- STYLES -->
             <Style x:Key="InfoButton" TargetType="ImageButton">
                 <Setter Property="Padding" Value="5" />
@@ -91,7 +97,11 @@
             <Style TargetType="Label">
                 <Setter Property="TextColor" Value="{StaticResource BlackColor}" />
             </Style>
-            
+
+            <Style x:Key="InvitationEntryUnderlineStyle" TargetType="BoxView">
+                <Setter Property="BackgroundColor" Value="{StaticResource DefaultPlaceholderColor}" />
+            </Style>
+
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/SafeAuthenticator/App.xaml
+++ b/SafeAuthenticator/App.xaml
@@ -16,6 +16,7 @@
             <Color x:Key="GreySmokeLightColor">#c2c1c1</Color>
             <Color x:Key="GreySmokeMediumColor">#8b8b8b</Color>
             <Color x:Key="GreySnowMediumColor">#e4e4e4</Color>
+            <Color x:Key="DefaultPlaceholderColor">#80000000</Color>
 
             <!-- CONVERTERS -->
             <converters:IsCollectionEmptyConverter x:Key="IsCollectionEmptyConverter" />
@@ -90,7 +91,7 @@
             <Style TargetType="Label">
                 <Setter Property="TextColor" Value="{StaticResource BlackColor}" />
             </Style>
-
+            
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/SafeAuthenticator/Controls/InvitationTokenEntryView.xaml
+++ b/SafeAuthenticator/Controls/InvitationTokenEntryView.xaml
@@ -27,6 +27,7 @@
 
             <controls:MaterialEntry x:Name="InvitationTokenEntry"
                                     Placeholder="Invitation token"
+                                    VerticalOptions="End"
                                     Text="{Binding Invitation}"
                                     HorizontalOptions="FillAndExpand" 
                                     ErrorDisplay="None"
@@ -35,6 +36,7 @@
             <Image Source="clipboardPaste"
                    Style="{DynamicResource ImageStyle}"
                    Grid.Column="1"
+                   VerticalOptions="End"
                    HorizontalOptions="End">
                 <Image.GestureRecognizers>
                     <TapGestureRecognizer NumberOfTapsRequired="1"
@@ -43,8 +45,8 @@
             </Image>
 
             <BoxView x:Name="underline"
-                     BackgroundColor="#80000000"
                      Grid.Row="1"
+                     BackgroundColor="{StaticResource DefaultPlaceholderColor}"
                      HorizontalOptions="FillAndExpand" 
                      Grid.Column="0"
                      Grid.ColumnSpan="2" 
@@ -53,7 +55,7 @@
                     <DataTrigger Binding="{Binding Source={x:Reference InvitationTokenEntry}, Path=IsFocused}" 
                                  Value="True"
                                  TargetType="BoxView" >
-                        <Setter Property="BackgroundColor" Value="#0074e4"/>
+                        <Setter Property="BackgroundColor" Value="{StaticResource PrimaryColor}"/>
                     </DataTrigger>
                 </BoxView.Triggers>
             </BoxView>

--- a/SafeAuthenticator/Controls/InvitationTokenEntryView.xaml
+++ b/SafeAuthenticator/Controls/InvitationTokenEntryView.xaml
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:SafeAuthenticator.Controls"
+             x:Class="SafeAuthenticator.Controls.InvitationTokenEntryView">
+    
+    <ContentView.Resources>
+        <ResourceDictionary>
+            <Style x:Key="ImageStyle" TargetType="Image">
+                <Setter Property="Aspect" Value="AspectFit" />
+                <Setter Property="HeightRequest" Value="30" />
+            </Style>
+        </ResourceDictionary>
+    </ContentView.Resources>
+    
+    <ContentView.Content>
+        <Grid RowSpacing="0"
+              VerticalOptions="CenterAndExpand">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <controls:MaterialEntry x:Name="InvitationTokenEntry"
+                                    Placeholder="Invitation token"
+                                    Text="{Binding Invitation}"
+                                    HorizontalOptions="FillAndExpand" 
+                                    ErrorDisplay="None"
+                                    IsUnderlineTransparent="true" />
+
+            <Image Source="clipboardPaste"
+                   Style="{DynamicResource ImageStyle}"
+                   Grid.Column="1"
+                   HorizontalOptions="End">
+                <Image.GestureRecognizers>
+                    <TapGestureRecognizer NumberOfTapsRequired="1"
+                                          Command="{Binding ClipboardPasteCommand}" />
+                </Image.GestureRecognizers>
+            </Image>
+
+            <BoxView x:Name="underline"
+                     BackgroundColor="#80000000"
+                     Grid.Row="1"
+                     HorizontalOptions="FillAndExpand" 
+                     Grid.Column="0"
+                     Grid.ColumnSpan="2" 
+                     HeightRequest="1.5">
+                <BoxView.Triggers>
+                    <DataTrigger Binding="{Binding Source={x:Reference InvitationTokenEntry}, Path=IsFocused}" 
+                                 Value="True"
+                                 TargetType="BoxView" >
+                        <Setter Property="BackgroundColor" Value="#0074e4"/>
+                    </DataTrigger>
+                </BoxView.Triggers>
+            </BoxView>
+        
+        </Grid>
+    </ContentView.Content>
+</ContentView>

--- a/SafeAuthenticator/Controls/InvitationTokenEntryView.xaml
+++ b/SafeAuthenticator/Controls/InvitationTokenEntryView.xaml
@@ -27,7 +27,6 @@
 
             <controls:MaterialEntry x:Name="InvitationTokenEntry"
                                     Placeholder="Invitation token"
-                                    VerticalOptions="End"
                                     Text="{Binding Invitation}"
                                     HorizontalOptions="FillAndExpand" 
                                     ErrorDisplay="None"
@@ -36,7 +35,6 @@
             <Image Source="clipboardPaste"
                    Style="{DynamicResource ImageStyle}"
                    Grid.Column="1"
-                   VerticalOptions="End"
                    HorizontalOptions="End">
                 <Image.GestureRecognizers>
                     <TapGestureRecognizer NumberOfTapsRequired="1"
@@ -46,7 +44,7 @@
 
             <BoxView x:Name="underline"
                      Grid.Row="1"
-                     BackgroundColor="{StaticResource DefaultPlaceholderColor}"
+                     Style="{StaticResource InvitationEntryUnderlineStyle}"
                      HorizontalOptions="FillAndExpand" 
                      Grid.Column="0"
                      Grid.ColumnSpan="2" 

--- a/SafeAuthenticator/Controls/InvitationTokenEntryView.xaml.cs
+++ b/SafeAuthenticator/Controls/InvitationTokenEntryView.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace SafeAuthenticator.Controls
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class InvitationTokenEntryView : ContentView
+    {
+        public InvitationTokenEntryView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SafeAuthenticator/Controls/MaterialEntry.cs
+++ b/SafeAuthenticator/Controls/MaterialEntry.cs
@@ -24,6 +24,12 @@ namespace SafeAuthenticator.Controls
             }
         }
 
+        public static readonly BindableProperty IsUnderlineTransparentProperty = BindableProperty.Create(
+            nameof(IsUnderlineTransparent),
+            typeof(bool),
+            typeof(MaterialEntry),
+            default(bool));
+
         public static readonly BindableProperty ErrorTextProperty = BindableProperty.Create(
             nameof(ErrorText),
             typeof(string),
@@ -73,6 +79,15 @@ namespace SafeAuthenticator.Controls
         {
             get => (string)GetValue(ErrorTextProperty);
             set => SetValue(ErrorTextProperty, value);
+        }
+
+        /// <summary>
+        /// If enabled this property makes the color of underline transparent. This is a bindable property.
+        /// </summary>
+        public bool IsUnderlineTransparent
+        {
+            get { return (bool)GetValue(IsUnderlineTransparentProperty); }
+            set { SetValue(IsUnderlineTransparentProperty, value); }
         }
 
         /// <summary>

--- a/SafeAuthenticator/SafeAuthenticator.csproj
+++ b/SafeAuthenticator/SafeAuthenticator.csproj
@@ -49,6 +49,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Controls\InvitationTokenEntryView.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Controls\MDataPermissionViewCell.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/SafeAuthenticator/Views/CreateAcctPage.xaml
+++ b/SafeAuthenticator/Views/CreateAcctPage.xaml
@@ -18,15 +18,11 @@
                 <Setter Property="FontSize" Value="{StaticResource LargeSize}" />
                 <Setter Property="FontAttributes" Value="Bold" />
             </Style>
-            <Style x:Key="ImageStyle" TargetType="Image">
-                <Setter Property="Aspect" Value="AspectFit" />
-                <Setter Property="HeightRequest" Value="30" />
-            </Style>
         </ResourceDictionary>
     </ContentPage.Resources>
 
     <ContentPage.Content>
-        <StackLayout Spacing="10">
+        <StackLayout Spacing="10" >
             <cv:CarouselViewControl                    
                     ShowArrows="False"
                     ShowIndicators="False"
@@ -55,7 +51,7 @@
                                                   TextDecorations="Underline">
                                                 <Span.GestureRecognizers>
                                                     <TapGestureRecognizer NumberOfTapsRequired="1"
-                                                                              Command="{Binding OpenForumLinkCommand}">
+                                                                          Command="{Binding OpenForumLinkCommand}">
                                                     </TapGestureRecognizer>
                                                 </Span.GestureRecognizers>
                                             </Span>
@@ -75,23 +71,8 @@
                                        Margin="0,20,0,0"
                                        Style="{DynamicResource TitleStyle}" />
 
-                                <StackLayout Orientation="Horizontal"
-                                                 Margin="0,20,0,0">
+                                <controls:InvitationTokenEntryView />
 
-                                    <controls:MaterialEntry Placeholder="Invitation token"
-                                                            Text="{Binding Invitation}"
-                                                            HorizontalOptions="FillAndExpand" 
-                                                            ErrorDisplay="None" />
-
-                                    <Image Source="clipboardPaste"
-                                           Style="{DynamicResource ImageStyle}"
-                                           Margin="0,0,0,5">
-                                        <Image.GestureRecognizers>
-                                            <TapGestureRecognizer NumberOfTapsRequired="1"
-                                                                  Command="{Binding ClipboardPasteCommand}" />
-                                        </Image.GestureRecognizers>
-                                    </Image>
-                                </StackLayout>
                             </StackLayout>
                         </StackLayout>
 
@@ -142,16 +123,16 @@
             </cv:CarouselViewControl>
 
             <Button Text="CONTINUE"
-                        Command="{Binding CarouselContinueCommand}"
-                        Margin="25,0"/>
+                    Command="{Binding CarouselContinueCommand}"
+                    Margin="25,0"/>
 
             <Button Text="BACK"
-                        HorizontalOptions="Center"
-                        Command="{Binding CarouselBackCommand}"
-                        IsVisible="{Binding IsBackButtonVisible}"
-                        BackgroundColor="Transparent"
-                        TextColor="{StaticResource PrimaryColor}"
-                        Margin="25,0"/>
+                    HorizontalOptions="Center"
+                    Command="{Binding CarouselBackCommand}"
+                    IsVisible="{Binding IsBackButtonVisible}"
+                    BackgroundColor="Transparent"
+                    TextColor="{StaticResource PrimaryColor}"
+                    Margin="25,0"/>
         </StackLayout>
 
     </ContentPage.Content>


### PR DESCRIPTION
fixes[#50](https://github.com/maidsafe/safe-authenticator-mobile/issues/50)

-added a box view under the entry and paste icon which will bring the icon inside invitation token entry.
-created a property in the material entry to make the underline transparent.
-created a new content view for the invitation entry along with the paste button in it as a grid.
-created a data trigger for changing the color of the box view when there is a focus in the entry.