### PR TITLE
Fix FAQ link in SettingsPage

### DIFF
--- a/SafeAuthenticator/Views/SettingsPage.xaml
+++ b/SafeAuthenticator/Views/SettingsPage.xaml
@@ -74,7 +74,7 @@
                            Style="{StaticResource ItemStyle}">
                         <Label.GestureRecognizers>
                             <TapGestureRecognizer NumberOfTapsRequired="1"
-                                                  Command="{Binding FAQCommand}" />
+                                                  Command="{Binding FaqCommand}" />
                         </Label.GestureRecognizers>
                     </Label>
 


### PR DESCRIPTION
Resolves #61 

The TapGestureRecognizer command binding set for the FAQ link in `SettingsPage` is not valid. Rename `FAQCommand` to `FaqCommand` in `SettingsPage`