### PR TITLE
Display TutorialPage as launch page unless its skiped or completed

### DIFF
--- a/SafeAuthenticator/App.xaml.cs
+++ b/SafeAuthenticator/App.xaml.cs
@@ -52,15 +52,10 @@ namespace SafeAuthenticator
 
         private Page NewStartupPage()
         {
-            if (!Current.Properties.ContainsKey(Constants.IsFirstLaunch))
-            {
-                Current.Properties[Constants.IsFirstLaunch] = true;
+            if (!Current.Properties.ContainsKey(Constants.IsTutorialComplete))
                 return new TutorialPage();
-            }
             else
-            {
                 return new LoginPage();
-            }
         }
 
         protected override async void OnStart()

--- a/SafeAuthenticator/Helpers/Constants.cs
+++ b/SafeAuthenticator/Helpers/Constants.cs
@@ -8,7 +8,7 @@
         internal const int AccStrengthSomeWhatSecure = 10;
 
         internal static readonly string AppName = "SAFE Authenticator";
-        internal static readonly string IsFirstLaunch = "IsFirstLaunch";
+        internal static readonly string IsTutorialComplete = "IsTutorialComplete";
 
         // Authentication PopupState
         internal static readonly string None = "None";

--- a/SafeAuthenticator/ViewModels/TutorialViewModel.cs
+++ b/SafeAuthenticator/ViewModels/TutorialViewModel.cs
@@ -64,6 +64,7 @@ namespace SafeAuthenticator.ViewModels
 
         private void OnSecondaryButton()
         {
+            Application.Current.Properties[Constants.IsTutorialComplete] = true;
             MessagingCenter.Send(
                 this,
                 CarouselPagePosition < 2 ? MessengerConstants.NavLoginPage : MessengerConstants.NavCreateAcctPage);
@@ -72,9 +73,14 @@ namespace SafeAuthenticator.ViewModels
         private void OnPrimaryButton()
         {
             if (CarouselPagePosition < 2)
+            {
                 CarouselPagePosition += 1;
+            }
             else
+            {
+                Application.Current.Properties[Constants.IsTutorialComplete] = true;
                 MessagingCenter.Send(this, MessengerConstants.NavLoginPage);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes: #63  
Display the `TutorialPage` as the launch page of the app unless the user skips the tutorial by clicking `Skip` or he completes the tutorial by clicking `Login`/ `Create Account` button.