### PR TITLE
Add tap animation for external links in SettingsPage

### DIFF
--- a/SafeAuthenticator.Android/MainActivity.cs
+++ b/SafeAuthenticator.Android/MainActivity.cs
@@ -92,6 +92,7 @@ namespace SafeAuthenticator.Droid
 
             base.OnCreate(bundle);
             Rg.Plugins.Popup.Popup.Init(this, bundle);
+            XamEffects.Droid.Effects.Init();
             Forms.Init(this, bundle);
 
             DisplayCrashReport();

--- a/SafeAuthenticator.Android/SafeAuthenticator.Android.csproj
+++ b/SafeAuthenticator.Android/SafeAuthenticator.Android.csproj
@@ -206,6 +206,9 @@
     <PackageReference Include="Xamarin.Forms">
       <Version>3.4.0.1008975</Version>
     </PackageReference>
+    <PackageReference Include="XamEffects">
+      <Version>1.5.6</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildThisFileDirectory)..\CodeStyles.targets" />
   <ItemGroup>

--- a/SafeAuthenticator.iOS/AppDelegate.cs
+++ b/SafeAuthenticator.iOS/AppDelegate.cs
@@ -23,6 +23,7 @@ namespace SafeAuthenticator.iOS
         {
             Rg.Plugins.Popup.Popup.Init();
             Forms.Init();
+            XamEffects.iOS.Effects.Init();
             CarouselViewRenderer.Init();
             LoadApplication(new App());
 

--- a/SafeAuthenticator.iOS/SafeAuthenticator.iOS.csproj
+++ b/SafeAuthenticator.iOS/SafeAuthenticator.iOS.csproj
@@ -243,6 +243,9 @@
     <PackageReference Include="Xamarin.Forms">
       <Version>3.4.0.1008975</Version>
     </PackageReference>
+    <PackageReference Include="XamEffects">
+      <Version>1.5.6</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildThisFileDirectory)..\CodeStyles.targets" />
   <ItemGroup>

--- a/SafeAuthenticator/SafeAuthenticator.csproj
+++ b/SafeAuthenticator/SafeAuthenticator.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="Xamarin.Essentials" Version="0.11.0-preview" />
     <PackageReference Include="Xamarin.Forms" Version="3.4.0.1008975" />
+    <PackageReference Include="XamEffects" Version="1.5.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SafeAuthenticator/Views/SettingsPage.xaml
+++ b/SafeAuthenticator/Views/SettingsPage.xaml
@@ -3,12 +3,14 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="SafeAuthenticator.Views.SettingsPage"
+             xmlns:xe="clr-namespace:XamEffects;assembly=XamEffects"             
              Title="Settings">
 
     <ContentPage.Resources>
         <ResourceDictionary>
             <Style x:Key="TitleStyle" TargetType="Label">
                 <Setter Property="FontSize" Value="{StaticResource ExtraLargeSize}" />
+                <Setter Property="TextColor" Value="{StaticResource PrimaryColor}" />
             </Style>
             <Style x:Key="ItemStyle" TargetType="Label">
                 <Setter Property="FontSize" Value="{StaticResource MediumSize}" />
@@ -20,6 +22,9 @@
                 <Setter Property="HeightRequest" Value="0.5" />
                 <Setter Property="Color" Value="{StaticResource GreySmokeMediumColor}" />
             </Style>
+            <Style x:Key="ExternalLinkStyle" TargetType="StackLayout">
+                <Setter Property="HeightRequest" Value="40" />
+            </Style>
         </ResourceDictionary>
     </ContentPage.Resources>
 
@@ -30,8 +35,7 @@
                 <StackLayout Padding="16, 10"
                              Spacing="15">
                     <Label Text="Account"
-                           Style="{StaticResource TitleStyle}" 
-                           TextColor="{StaticResource PrimaryColor}"/>
+                           Style="{StaticResource TitleStyle}" />
                     <StackLayout>
                         <StackLayout Orientation="Horizontal">
                             <Label Text="Account Status"
@@ -64,29 +68,35 @@
                     </Grid>
                 </StackLayout>
 
-                <BoxView Style="{StaticResource BoxViewStyle}"/>
+                <BoxView Style="{StaticResource BoxViewStyle}" />
 
-                <StackLayout Padding="16, 0" Spacing="20">
+                <StackLayout Spacing="0">
 
                     <Label Text="Help"
+                           Margin="16,0,16,10"
                            Style="{StaticResource TitleStyle}" />
-                    <Label Text="FAQs"
-                           Style="{StaticResource ItemStyle}">
-                        <Label.GestureRecognizers>
-                            <TapGestureRecognizer NumberOfTapsRequired="1"
-                                                  Command="{Binding FAQCommand}" />
-                        </Label.GestureRecognizers>
-                    </Label>
 
-                    <Label Text="Privacy statement" 
-                           Style="{StaticResource ItemStyle}" >
-                        <Label.GestureRecognizers>
-                            <TapGestureRecognizer NumberOfTapsRequired="1"
-                                                  Command="{Binding PrivacyInfoCommand}" />
-                        </Label.GestureRecognizers>
-                    </Label>
-                    
-                    <StackLayout>
+                    <StackLayout xe:TouchEffect.Color="{StaticResource GreySmokeMediumColor}"
+                                 xe:Commands.Tap="{Binding FaqCommand}"
+                                 Style="{StaticResource ExternalLinkStyle}">
+                        
+                        <Label Text="FAQs"
+                               Margin="16,0"
+                               Style="{StaticResource ItemStyle}"
+                               VerticalOptions="CenterAndExpand" />
+                    </StackLayout>
+
+                    <StackLayout xe:TouchEffect.Color="{StaticResource GreySmokeMediumColor}"
+                                 xe:Commands.Tap="{Binding PrivacyInfoCommand}"
+                                 Style="{StaticResource ExternalLinkStyle}">
+
+                        <Label Text="Privacy statement"
+                               Margin="16,0"
+                               Style="{StaticResource ItemStyle}"
+                               VerticalOptions="CenterAndExpand" />
+                    </StackLayout>
+
+                    <StackLayout Margin="16,10">
                         <Label Text="Application version"
                                Style="{StaticResource ItemStyle}" />
                         <Label Text="0.1.0" 

--- a/SafeAuthenticator/Views/SettingsPage.xaml
+++ b/SafeAuthenticator/Views/SettingsPage.xaml
@@ -3,7 +3,7 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="SafeAuthenticator.Views.SettingsPage"
-             xmlns:xe="clr-namespace:XamEffects;assembly=XamEffects"             
+             xmlns:XamEffects="clr-namespace:XamEffects;assembly=XamEffects"             
              Title="Settings">
 
     <ContentPage.Resources>
@@ -79,8 +79,8 @@
                            Margin="16,0,16,10"
                            Style="{StaticResource TitleStyle}" />
 
-                    <StackLayout xe:TouchEffect.Color="{StaticResource GreySmokeMediumColor}"
-                                 xe:Commands.Tap="{Binding FaqCommand}"
+                    <StackLayout XamEffects:TouchEffect.Color="{StaticResource GreySmokeMediumColor}"
+                                 XamEffects:Commands.Tap="{Binding FaqCommand}"
                                  Style="{StaticResource ExternalLinkStyle}">
                         
                         <Label Text="FAQs"
@@ -89,8 +89,8 @@
                                VerticalOptions="CenterAndExpand" />
                     </StackLayout>
 
-                    <StackLayout xe:TouchEffect.Color="{StaticResource GreySmokeMediumColor}"
-                                 xe:Commands.Tap="{Binding PrivacyInfoCommand}"
+                    <StackLayout XamEffects:TouchEffect.Color="{StaticResource GreySmokeMediumColor}"
+                                 XamEffects:Commands.Tap="{Binding PrivacyInfoCommand}"
                                  Style="{StaticResource ExternalLinkStyle}">
 
                         <Label Text="Privacy statement"


### PR DESCRIPTION
Fixes #68 
Use [XamEffects](https://github.com/mrxten/XamEffects) to add tap animation to external links (FAQ and Privacy policy) in SettingsPage.

**Tap animation in Android and iOS**
![collage1](https://user-images.githubusercontent.com/22762119/52783366-ae98c600-3077-11e9-8846-2d46c6c55a8c.jpg)