### PR TITLE
Login page title is shown for fraction of a second and disappears

### DIFF
--- a/SafeAuthenticator/Views/AppInfoPage.xaml
+++ b/SafeAuthenticator/Views/AppInfoPage.xaml
@@ -27,7 +27,7 @@
                 <Setter Property="FontSize" Value="{StaticResource SmallSize}" />
             </Style>
             <Style x:Key="RevokeButtonStyle" TargetType="Button">
-                <Setter Property="MinimumHeightRequest" Value="50" />
+                <Setter Property="HeightRequest" Value="35" />
                 <Setter Property="Padding" Value="5" />
                 <Setter Property="WidthRequest" Value="100" />
             </Style>
@@ -40,6 +40,10 @@
             <Grid RowSpacing="10"
                   VerticalOptions="CenterAndExpand"
                   ColumnSpacing="15">
+
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
 
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="3*" />
@@ -61,6 +65,7 @@
                         Style="{StaticResource RevokeButtonStyle}"
                         Text="REVOKE"
                         HorizontalOptions="End"
+                        VerticalOptions="StartAndExpand"
                         Command="{Binding RevokeAppCommand}" />
             </Grid>
 

--- a/SafeAuthenticator/Views/LoginPage.xaml
+++ b/SafeAuthenticator/Views/LoginPage.xaml
@@ -6,7 +6,7 @@
              xmlns:controls="clr-namespace:SafeAuthenticator.Controls"
              x:Class="SafeAuthenticator.Views.LoginPage" 
              NavigationPage.HasNavigationBar="False"
-             Title="Login"
+             NavigationPage.BackButtonTitle="Login"
              IsEnabled="{Binding IsUiEnabled}">
 
     <ContentPage.BindingContext>

--- a/SafeAuthenticator/Views/TutorialPage.xaml
+++ b/SafeAuthenticator/Views/TutorialPage.xaml
@@ -6,6 +6,7 @@
              xmlns:viewModels="clr-namespace:SafeAuthenticator.ViewModels"
              xmlns:controls="clr-namespace:SafeAuthenticator.Controls;assembly=SafeAuthenticator"
              x:Class="SafeAuthenticator.Views.TutorialPage"
+             NavigationPage.BackButtonTitle="Login"
              NavigationPage.HasNavigationBar="False">
 
     <ContentPage.BindingContext>


### PR DESCRIPTION
Fixes #62 #59  
- Disable title in LoginPage, this will prevent the Login page title from being shown for fraction of a second and disappearing, when we click back button from `Create Account` page
- Set the `BackButtonTitle` property as `Login` in `TutorialPage` this will prevent the back button's title from changing when navigating from feature screens in iOS