### PR TITLE
Display progress dialogs natively for Android and iOS

### DIFF
--- a/SafeAuthenticator.Android/Helpers/AndroidNativeProgressDialogService.cs
+++ b/SafeAuthenticator.Android/Helpers/AndroidNativeProgressDialogService.cs
@@ -2,6 +2,7 @@
 using Android.App;
 using SafeAuthenticator.Controls;
 using SafeAuthenticator.Droid.Helpers;
+using SafeAuthenticator.Models;
 using Xamarin.Forms;
 
 [assembly: Dependency(typeof(AndroidNativeProgressDialogService))]

--- a/SafeAuthenticator.Android/Helpers/AndroidNativeProgressDialogService.cs
+++ b/SafeAuthenticator.Android/Helpers/AndroidNativeProgressDialogService.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Android.App;
+using SafeAuthenticator.Controls;
+using SafeAuthenticator.Droid.Helpers;
+using Xamarin.Forms;
+
+[assembly: Dependency(typeof(AndroidNativeProgressDialogService))]
+namespace SafeAuthenticator.Droid.Helpers
+{
+    public class AndroidNativeProgressDialogService : INativeProgressDialogService
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        ProgressDialog progress = new ProgressDialog((Activity)Forms.Context);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        public void HideNativeDialog()
+        {
+            progress.Dismiss();
+        }
+
+        public IDisposable ShowNativeDialog(string message, string title)
+        {
+            progress.Indeterminate = true;
+            progress.SetProgressStyle(ProgressDialogStyle.Spinner);
+            progress.SetTitle(title);
+            progress.SetMessage(message);
+            progress.SetCancelable(false);
+            progress.Show();
+            return new DisposableAction(() => { progress.Dismiss(); });
+        }
+    }
+}

--- a/SafeAuthenticator.Android/MainActivity.cs
+++ b/SafeAuthenticator.Android/MainActivity.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
-using Acr.UserDialogs;
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
@@ -96,8 +95,6 @@ namespace SafeAuthenticator.Droid
             Forms.Init(this, bundle);
 
             DisplayCrashReport();
-
-            UserDialogs.Init(this);
             CarouselViewRenderer.Init();
             LoadApplication(new App());
 

--- a/SafeAuthenticator.Android/SafeAuthenticator.Android.csproj
+++ b/SafeAuthenticator.Android/SafeAuthenticator.Android.csproj
@@ -76,6 +76,7 @@
       <Link>Helpers\AuthBindings.Manual.cs</Link>
     </Compile>
     <Compile Include="Helpers\AndroidNativeBrowserService.cs" />
+    <Compile Include="Helpers\AndroidNativeProgressDialogService.cs" />
     <Compile Include="Helpers\EntryMoveNextEffect.cs" />
     <Compile Include="Helpers\FileOps.cs" />
     <Compile Include="Helpers\FontExtensions.cs" />
@@ -128,12 +129,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Acr.Support">
-      <Version>2.1.0</Version>
-    </PackageReference>
-    <PackageReference Include="Acr.UserDialogs">
-      <Version>7.0.1</Version>
-    </PackageReference>
     <PackageReference Include="CarouselView.FormsPlugin">
       <Version>5.2.0</Version>
     </PackageReference>

--- a/SafeAuthenticator.iOS/Helpers/AppleNativeProgressDialogService.cs
+++ b/SafeAuthenticator.iOS/Helpers/AppleNativeProgressDialogService.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using BigTed;
+using SafeAuthenticator.Controls;
+using SafeAuthenticator.iOS.Helpers;
+using Xamarin.Forms;
+
+[assembly: Dependency(typeof(AppleNativeProgressDialogService))]
+namespace SafeAuthenticator.iOS.Helpers
+{
+    class AppleNativeProgressDialogService : INativeProgressDialogService
+    {
+        public void HideNativeDialog()
+        {
+            BTProgressHUD.Dismiss();
+        }
+
+        public IDisposable ShowNativeDialog(string message, string title)
+        {
+            BTProgressHUD.Show(message, -1, ProgressHUD.MaskType.Black);
+            return new DisposableAction(() => { BTProgressHUD.Dismiss(); });
+        }
+    }
+}

--- a/SafeAuthenticator.iOS/Helpers/AppleNativeProgressDialogService.cs
+++ b/SafeAuthenticator.iOS/Helpers/AppleNativeProgressDialogService.cs
@@ -2,6 +2,7 @@
 using BigTed;
 using SafeAuthenticator.Controls;
 using SafeAuthenticator.iOS.Helpers;
+using SafeAuthenticator.Models;
 using Xamarin.Forms;
 
 [assembly: Dependency(typeof(AppleNativeProgressDialogService))]

--- a/SafeAuthenticator.iOS/SafeAuthenticator.iOS.csproj
+++ b/SafeAuthenticator.iOS/SafeAuthenticator.iOS.csproj
@@ -160,6 +160,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Extensions\ColorExtension.cs" />
     <Compile Include="Helpers\AppleNativeBrowserService.cs" />
+    <Compile Include="Helpers\AppleNativeProgressDialogService.cs" />
     <Compile Include="Helpers\BorderlessEntryRenderer.cs" />
     <Compile Include="Helpers\EntryMoveNextEffect.cs" />
     <Compile Include="Helpers\FileOps.cs" />
@@ -210,11 +211,8 @@
     </NativeReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Acr.Support">
-      <Version>2.1.0</Version>
-    </PackageReference>
-    <PackageReference Include="Acr.UserDialogs">
-      <Version>7.0.1</Version>
+    <PackageReference Include="BTProgressHUD">
+      <Version>1.2.0.6</Version>
     </PackageReference>
     <PackageReference Include="CarouselView.FormsPlugin">
       <Version>5.2.0</Version>

--- a/SafeAuthenticator/Controls/DisposableAction.cs
+++ b/SafeAuthenticator/Controls/DisposableAction.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace SafeAuthenticator.Controls
+{
+    public class DisposableAction : IDisposable
+    {
+        readonly Action action;
+
+        public DisposableAction(Action action)
+        {
+            this.action = action;
+        }
+
+        public void Dispose()
+        {
+            action();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/SafeAuthenticator/Controls/INativeProgressDialogService.cs
+++ b/SafeAuthenticator/Controls/INativeProgressDialogService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SafeAuthenticator.Controls
+{
+    public interface INativeProgressDialogService
+    {
+        IDisposable ShowNativeDialog(string message, string title = null);
+
+        void HideNativeDialog();
+    }
+}

--- a/SafeAuthenticator/Models/DisposableAction.cs
+++ b/SafeAuthenticator/Models/DisposableAction.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace SafeAuthenticator.Controls
+namespace SafeAuthenticator.Models
 {
     public class DisposableAction : IDisposable
     {

--- a/SafeAuthenticator/SafeAuthenticator.csproj
+++ b/SafeAuthenticator/SafeAuthenticator.csproj
@@ -26,7 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Acr.UserDialogs" Version="7.0.1" />
     <PackageReference Include="CarouselView.FormsPlugin" Version="5.2.0" />
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
     <PackageReference Include="Jint" Version="2.10.3" />

--- a/SafeAuthenticator/Services/AuthService.cs
+++ b/SafeAuthenticator/Services/AuthService.cs
@@ -4,8 +4,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Acr.UserDialogs;
 using Rg.Plugins.Popup.Extensions;
+using SafeAuthenticator.Controls;
 using SafeAuthenticator.Helpers;
 using SafeAuthenticator.Models;
 using SafeAuthenticator.Native;
@@ -26,6 +26,8 @@ namespace SafeAuthenticator.Services
         private bool _isLogInitialised;
         private string _secret;
         private string _password;
+
+        protected INativeProgressDialogService NativeProgressDialog => DependencyService.Get<INativeProgressDialogService>();
 
         public string AuthenticationReq { get; set; }
 
@@ -92,7 +94,7 @@ namespace SafeAuthenticator.Services
                     if (AuthReconnect)
                     {
                         var (location, password) = await CredentialCache.Retrieve();
-                        using (UserDialogs.Instance.Loading("Reconnecting to Network"))
+                        using (NativeProgressDialog.ShowNativeDialog("Reconnecting to Network"))
                         {
                             await LoginAsync(location, password);
                             MessagingCenter.Send(this, MessengerConstants.NavHomePage);
@@ -101,7 +103,7 @@ namespace SafeAuthenticator.Services
                 }
                 else if (_authenticator.IsDisconnected)
                 {
-                    using (UserDialogs.Instance.Loading("Reconnecting to Network"))
+                    using (NativeProgressDialog.ShowNativeDialog("Reconnecting to Network"))
                     {
                         await LoginAsync(_secret, _password);
                     }

--- a/SafeAuthenticator/ViewModels/AppInfoViewModel.cs
+++ b/SafeAuthenticator/ViewModels/AppInfoViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Windows.Input;
-using Acr.UserDialogs;
 using JetBrains.Annotations;
 using SafeAuthenticator.Helpers;
 using SafeAuthenticator.Models;
@@ -39,7 +38,7 @@ namespace SafeAuthenticator.ViewModels
             {
                 try
                 {
-                    using (UserDialogs.Instance.Loading("Revoking app access"))
+                    using (NativeProgressDialog.ShowNativeDialog("Revoking app access"))
                     {
                         await Authenticator.RevokeAppAsync(_appModelInfo.AppId);
                         MessagingCenter.Send(this, MessengerConstants.NavHomePage);

--- a/SafeAuthenticator/ViewModels/BaseViewModel.cs
+++ b/SafeAuthenticator/ViewModels/BaseViewModel.cs
@@ -10,5 +10,7 @@ namespace SafeAuthenticator.ViewModels
         protected AuthService Authenticator => DependencyService.Get<AuthService>();
 
         protected INativeBrowserService OpeNativeBrowserService => DependencyService.Get<INativeBrowserService>();
+
+        protected INativeProgressDialogService NativeProgressDialog => DependencyService.Get<INativeProgressDialogService>();
     }
 }

--- a/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
+++ b/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using Acr.UserDialogs;
 using SafeAuthenticator.Helpers;
 using SafeAuthenticator.Models;
 using SafeAuthenticator.Native;
@@ -171,7 +170,7 @@ namespace SafeAuthenticator.ViewModels
             {
                 if (CarouselPagePosition == 1)
                 {
-                    using (UserDialogs.Instance.Loading("Checking secret strength"))
+                    using (NativeProgressDialog.ShowNativeDialog("Checking secret strength"))
                     {
                         await Task.Run(() =>
                         {
@@ -212,7 +211,7 @@ namespace SafeAuthenticator.ViewModels
 
         private async Task CreateAcct()
         {
-            using (UserDialogs.Instance.Loading("Creating account"))
+            using (NativeProgressDialog.ShowNativeDialog("Creating account"))
             {
                 await Task.Run(() =>
                 {

--- a/SafeAuthenticator/ViewModels/LoginViewModel.cs
+++ b/SafeAuthenticator/ViewModels/LoginViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Windows.Input;
-using Acr.UserDialogs;
 using SafeAuthenticator.Helpers;
 using SafeAuthenticator.Native;
 using Xamarin.Forms;
@@ -80,7 +79,7 @@ namespace SafeAuthenticator.ViewModels
         {
             try
             {
-                using (UserDialogs.Instance.Loading("Logging in"))
+                using (NativeProgressDialog.ShowNativeDialog("Logging in"))
                 {
                     await Authenticator.LoginAsync(AccountSecret, AccountPassword);
                     MessagingCenter.Send(this, MessengerConstants.NavHomePage);


### PR DESCRIPTION
fixes[#52](https://github.com/maidsafe/safe-authenticator-mobile/issues/52)

- Added a dependency service for displaying the progress dialog natively.
- Implemented native Android progress dialog in SafeAuthenticator.Android.
- Implemented iOS native progress using BTProgressHUD custom progress dialog in SafeAuthenticator.iOS.
- Added a separate class for Disposable action to make the dialog disposable.
- Removed the Third party ACR dialog NuGet package.

Screen Shots
*Android*

<img src="https://user-images.githubusercontent.com/45584218/52807961-de18f400-30b2-11e9-904c-ab13a2eda933.jpg" height="500" alt="progressdialog_android">

*iOS*

<img src="https://user-images.githubusercontent.com/45584218/52807904-b9bd1780-30b2-11e9-9545-5f85b0f88873.png" height="500" alt="progressdialog_ios">
