### PR TITLE
 Add height to label to avoid cropping and to increase clickable area

### DIFF
--- a/SafeAuthenticator/Views/LoginPage.xaml
+++ b/SafeAuthenticator/Views/LoginPage.xaml
@@ -20,7 +20,8 @@
                 <Setter Property="FontAttributes" Value="Bold" />
             </Style>
             <Style x:Key="NeedHelpStyle" TargetType="Label">
-                <Setter Property="HeightRequest" Value="{StaticResource ExtraLargeSize}" />
+                <Setter Property="FontSize" Value="{StaticResource MediumSize}" />
+                <Setter Property="HeightRequest" Value="30" />
                 <Setter Property="FontAttributes" Value="Bold" />
             </Style>
             <Style x:Key="ImageStyle" TargetType="Image">


### PR DESCRIPTION

fixes #69 

- Change the font size of "Need any help!" to avoid cropping.
- Add height request to increase the clickable area of the label.

