### PR TITLE
Display error message if secret/password "confirm" fields don't match

### DIFF
--- a/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
+++ b/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
@@ -154,11 +154,21 @@ namespace SafeAuthenticator.ViewModels
                 case 0:
                     return !string.IsNullOrWhiteSpace(Invitation);
                 case 1:
-                    return !string.IsNullOrWhiteSpace(AcctSecret) && !string.IsNullOrWhiteSpace(ConfirmAcctSecret) &&
-                        AcctSecret == ConfirmAcctSecret;
+                    {
+                        if (AcctSecret == ConfirmAcctSecret)
+                        {
+                            AcctSecretErrorMsg = string.Empty;
+                        }
+                        return !string.IsNullOrWhiteSpace(AcctSecret) && !string.IsNullOrWhiteSpace(ConfirmAcctSecret);
+                    }
                 case 2:
-                    return !string.IsNullOrWhiteSpace(AcctPassword) && !string.IsNullOrWhiteSpace(ConfirmAcctPassword) &&
-                        AcctPassword == ConfirmAcctPassword;
+                    {
+                        if (AcctPassword == ConfirmAcctPassword)
+                        {
+                            AcctPasswordErrorMsg = string.Empty;
+                        }
+                        return !string.IsNullOrWhiteSpace(AcctPassword) && !string.IsNullOrWhiteSpace(ConfirmAcctPassword);
+                    }
                 default:
                     return true;
             }
@@ -170,6 +180,13 @@ namespace SafeAuthenticator.ViewModels
             {
                 if (CarouselPagePosition == 1)
                 {
+                    if (AcctSecret != ConfirmAcctSecret)
+                    {
+                        AcctSecretErrorMsg = "Secret doesn't match";
+                        ((Command)CarouselContinueCommand).ChangeCanExecute();
+                        return;
+                    }
+
                     using (NativeProgressDialog.ShowNativeDialog("Checking secret strength"))
                     {
                         await Task.Run(() =>
@@ -186,9 +203,19 @@ namespace SafeAuthenticator.ViewModels
                 }
 
                 if (CarouselPagePosition < 2)
+                {
                     CarouselPagePosition += 1;
+                }
                 else
+                {
+                    if (AcctPassword != ConfirmAcctPassword)
+                    {
+                        AcctPasswordErrorMsg = "Password doesn't match";
+                        ((Command)CarouselContinueCommand).ChangeCanExecute();
+                        return;
+                    }
                     await CreateAcct();
+                }
             }
             catch (FfiException ex)
             {


### PR DESCRIPTION
fixes #81 
-  Add a condition to check the secret and confirm secret is matching, if not set the error message "Secret doesn't match".
- Add a condition to check the password and confirm password is matching, if not set the error message "password doesn't match".
- Check for the secret/password strength after the confirm field  check.

<img src="https://user-images.githubusercontent.com/45584218/53019717-60bafe00-347b-11e9-9587-a3ec19767e72.png" height="500" alt="screenshot_1550577964">
<img src="https://user-images.githubusercontent.com/45584218/53019718-60bafe00-347b-11e9-9bc9-386074fa25e5.png" height="500" alt="screenshot_1550578003">
<img src="https://user-images.githubusercontent.com/45584218/53019719-60bafe00-347b-11e9-916a-537e8639dd62.png" height="500" alt="screenshot_1550578013">
<img src="https://user-images.githubusercontent.com/45584218/53019720-61539480-347b-11e9-8837-91b62778be44.png" height="500" alt="screenshot_1550578056">
<img src="https://user-images.githubusercontent.com/45584218/53019721-61539480-347b-11e9-9129-733a3f7dd537.png" height="500" alt="screenshot_1550578146">
<img src="https://user-images.githubusercontent.com/45584218/53019723-61539480-347b-11e9-8749-88ed490a7707.png" height="500" alt="screenshot_1550578152">
<img src="https://user-images.githubusercontent.com/45584218/53019724-61ec2b00-347b-11e9-9ad6-d2e7f091424b.png" height="500" alt="screenshot_1550578166">
