### PR TITLE
Enable scroll when keyboard is displayed

### DIFF
--- a/SafeAuthenticator.Android/MainActivity.cs
+++ b/SafeAuthenticator.Android/MainActivity.cs
@@ -97,6 +97,7 @@ namespace SafeAuthenticator.Droid
             DisplayCrashReport();
             CarouselViewRenderer.Init();
             LoadApplication(new App());
+            Window.SetSoftInputMode(Android.Views.SoftInput.AdjustResize);
 
             if (Intent?.Data != null)
             {

--- a/SafeAuthenticator.iOS/Helpers/CustomScrollViewRenderer.cs
+++ b/SafeAuthenticator.iOS/Helpers/CustomScrollViewRenderer.cs
@@ -1,0 +1,34 @@
+﻿using System.ComponentModel;
+using CoreGraphics;
+using SafeAuthenticator.Controls;
+using SafeAuthenticator.iOS.Helpers;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportRenderer(typeof(CustomScrollView), typeof(CustomScrollViewRenderer))]
+namespace SafeAuthenticator.iOS.Helpers
+{
+    class CustomScrollViewRenderer : ScrollViewRenderer
+    {
+        protected override void OnElementChanged(VisualElementChangedEventArgs e)
+        {
+            base.OnElementChanged(e);
+            ScrollEnabled = ((CustomScrollView)e.NewElement).IsScrollEnabled;
+            ((CustomScrollView)e.NewElement).PropertyChanged += OnPropertyChanged;
+        }
+
+        private void OnPropertyChanged(object sender, PropertyChangedEventArgs propertyChangedEventArgs)
+        {
+            if (!(propertyChangedEventArgs.PropertyName == "IsScrollEnabled"))
+                return;
+
+            var isScrollEnabled = ((CustomScrollView)sender).IsScrollEnabled;
+
+            // IsScrollEnabled is a custom property used to enable/disable scroll
+            // Reset the ScrollView to its original position if false
+            if (!isScrollEnabled)
+                ContentOffset = new CGPoint(0, 0);
+            ScrollEnabled = isScrollEnabled;
+        }
+    }
+}

--- a/SafeAuthenticator.iOS/SafeAuthenticator.iOS.csproj
+++ b/SafeAuthenticator.iOS/SafeAuthenticator.iOS.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Helpers\AppleNativeBrowserService.cs" />
     <Compile Include="Helpers\AppleNativeProgressDialogService.cs" />
     <Compile Include="Helpers\BorderlessEntryRenderer.cs" />
+    <Compile Include="Helpers\CustomScrollViewRenderer.cs" />
     <Compile Include="Helpers\EntryMoveNextEffect.cs" />
     <Compile Include="Helpers\FileOps.cs" />
     <Compile Include="Extensions\FontExtensions.cs" />

--- a/SafeAuthenticator/Controls/CustomScrollView.cs
+++ b/SafeAuthenticator/Controls/CustomScrollView.cs
@@ -1,0 +1,22 @@
+﻿using Xamarin.Forms;
+
+namespace SafeAuthenticator.Controls
+{
+    public class CustomScrollView : ScrollView
+    {
+        public static readonly BindableProperty IsScrollEnabledProperty = BindableProperty.Create(
+            nameof(IsScrollEnabled),
+            typeof(bool),
+            typeof(CustomScrollView),
+            default(bool));
+
+        /// <summary>
+        /// This property can be used to enabled/disable the scroll
+        /// </summary>
+        public bool IsScrollEnabled
+        {
+            get { return (bool)GetValue(IsScrollEnabledProperty); }
+            set { SetValue(IsScrollEnabledProperty, value); }
+        }
+    }
+}

--- a/SafeAuthenticator/Views/CreateAcctPage.xaml
+++ b/SafeAuthenticator/Views/CreateAcctPage.xaml
@@ -22,8 +22,9 @@
     </ContentPage.Resources>
 
     <ContentPage.Content>
-        <StackLayout Spacing="10" >
-            <cv:CarouselViewControl                    
+        <ScrollView>
+            <StackLayout Spacing="10">
+                <cv:CarouselViewControl
                     ShowArrows="False"
                     ShowIndicators="False"
                     IsSwipeEnabled="False"
@@ -31,34 +32,34 @@
                     PositionSelectedCommand="{Binding CarouselPageChangeCommand}"
                     Position="{Binding CarouselPagePosition}"
                     Margin="0,40,0,0">
-                <cv:CarouselViewControl.ItemsSource>
-                    <x:Array Type="{x:Type View}">
+                    <cv:CarouselViewControl.ItemsSource>
+                        <x:Array Type="{x:Type View}">
 
-                        <!-- Invitation -->
-                        <controls:CreateAcctStep1/>
+                            <!-- Invitation -->
+                            <controls:CreateAcctStep1/>
 
-                        <!-- Account Secret -->
-                        <controls:CreateAcctStep2/>
+                            <!-- Account Secret -->
+                            <controls:CreateAcctStep2/>
 
-                        <!-- Account Password -->
-                        <controls:CreateAcctStep3/>
-                        
-                    </x:Array>
-                </cv:CarouselViewControl.ItemsSource>
-            </cv:CarouselViewControl>
+                            <!-- Account Password -->
+                            <controls:CreateAcctStep3/>
 
-            <Button Text="CONTINUE"
+                        </x:Array>
+                    </cv:CarouselViewControl.ItemsSource>
+                </cv:CarouselViewControl>
+
+                <Button Text="CONTINUE"
                     Command="{Binding CarouselContinueCommand}"
                     Margin="25,0"/>
 
-            <Button Text="BACK"
+                <Button Text="BACK"
                     HorizontalOptions="Center"
                     Command="{Binding CarouselBackCommand}"
                     IsVisible="{Binding IsBackButtonVisible}"
                     BackgroundColor="Transparent"
                     TextColor="{StaticResource PrimaryColor}"
                     Margin="25,0"/>
-        </StackLayout>
-
+            </StackLayout>
+        </ScrollView>
     </ContentPage.Content>
 </ContentPage>

--- a/SafeAuthenticator/Views/LoginPage.xaml
+++ b/SafeAuthenticator/Views/LoginPage.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewModels="clr-namespace:SafeAuthenticator.ViewModels;assembly=SafeAuthenticator"
              xmlns:controls="clr-namespace:SafeAuthenticator.Controls"
-             x:Class="SafeAuthenticator.Views.LoginPage" 
+             x:Class="SafeAuthenticator.Views.LoginPage"
              NavigationPage.HasNavigationBar="False"
              NavigationPage.BackButtonTitle="Login"
              IsEnabled="{Binding IsUiEnabled}">
@@ -32,7 +32,9 @@
     </ContentPage.Resources>
 
     <ContentPage.Content>
-        <ScrollView Padding="25">
+        <controls:CustomScrollView  x:Name="ScrollLayout"
+                                    Padding="25"
+                                    IsScrollEnabled="False">
             <StackLayout>
                 <StackLayout VerticalOptions="CenterAndExpand"
                              Spacing="10">
@@ -47,21 +49,25 @@
                            Margin="0,10,0,0" />
 
                     <controls:MaterialEntry x:Name="SecretEntry"
-                                            Placeholder="Account Secret" 
+                                            Placeholder="Account Secret"
                                             IsPassword="True"
                                             ErrorDisplay="None"
                                             Margin="0,50,0,0"
-                                            Text="{Binding AccountSecret}"                                                                                        
+                                            Text="{Binding AccountSecret}"
                                             NextEntry="{Reference PasswordEntry}"
-                                            ReturnType="Next" />
+                                            ReturnType="Next"
+                                            Focused="CustomEntryFocused"
+                                            Unfocused="CustomEntryUnfocused"/>
 
                     <controls:MaterialEntry x:Name="PasswordEntry"
                                             Placeholder="Account Password" 
                                             IsPassword="True"
                                             ErrorDisplay="None"
                                             Text="{Binding AccountPassword}"
-                                            ReturnType="Done" 
-                                            ReturnCommand="{Binding LoginCommand}"/>
+                                            ReturnType="Done"
+                                            ReturnCommand="{Binding LoginCommand}"
+                                            Focused="CustomEntryFocused"
+                                            Unfocused="CustomEntryUnfocused"/>
 
                     <Button Text="LOGIN"
                             Command="{Binding LoginCommand}"
@@ -85,6 +91,6 @@
                     </Label.GestureRecognizers>
                 </Label>
             </StackLayout>
-        </ScrollView>
+        </controls:CustomScrollView>
     </ContentPage.Content>
 </ContentPage>

--- a/SafeAuthenticator/Views/LoginPage.xaml.cs
+++ b/SafeAuthenticator/Views/LoginPage.xaml.cs
@@ -68,5 +68,15 @@ namespace SafeAuthenticator.Views
             MessagingCenter.Unsubscribe<LoginViewModel>(this, MessengerConstants.NavHomePage);
             MessagingCenter.Unsubscribe<LoginViewModel>(this, MessengerConstants.NavCreateAcctPage);
         }
+
+        private void CustomEntryFocused(object sender, FocusEventArgs e)
+        {
+            ScrollLayout.IsScrollEnabled = true;
+        }
+
+        private void CustomEntryUnfocused(object sender, FocusEventArgs e)
+        {
+            ScrollLayout.IsScrollEnabled = false;
+        }
     }
 }


### PR DESCRIPTION
Fixes #60 

The page is to be scrollable when the keyboard is displayed on the screen
- On iOS: Create a CustomScrollView, such that initially the scrollView for the page is disabled and using the `Entry`'s `Focused` and `Unfocused` events we can enable/disable the scroll. 
- On Android: Resize the window using `SetSoftInputMode` (we do not require a custom control here, since by default only if the contents exceed the view scroll is enabled)

