### PR TITLE
Increase global font sizes for iOS

### DIFF
--- a/SafeAuthenticator/App.xaml
+++ b/SafeAuthenticator/App.xaml
@@ -15,6 +15,7 @@
             <Color x:Key="RedColor">#d94a3d</Color>
             <Color x:Key="GreySmokeLightColor">#c2c1c1</Color>
             <Color x:Key="GreySmokeMediumColor">#8b8b8b</Color>
+            <Color x:Key="GreySmokeDarkColor">#555555</Color>
             <Color x:Key="GreySnowMediumColor">#e4e4e4</Color>
             <Color x:Key="DefaultAndroidPlaceholderColor">#80000000</Color>
             <Color x:Key="DefaultiOSPlaceholderColor">#a9a9a9</Color>
@@ -36,28 +37,28 @@
 
             <OnPlatform x:Key="EntryHeightRequest"
                         x:TypeArguments="x:Double"
-                        Android="40" 
+                        Android="40"
                         iOS="40" />
             
             <OnPlatform x:Key="SmallSize"
                         x:TypeArguments="x:Double"
-                        Android="12" 
-                        iOS="11" />
+                        Android="12"
+                        iOS="14" />
 
             <OnPlatform x:Key="MediumSize"
                         x:TypeArguments="x:Double"
                         Android="14"
-                        iOS="12" />
+                        iOS="16" />
 
             <OnPlatform x:Key="LargeSize"
                         x:TypeArguments="x:Double"
                         Android="16"
-                        iOS="14" />
+                        iOS="18" />
 
             <OnPlatform x:Key="ExtraLargeSize"
                         x:TypeArguments="x:Double"
                         Android="18"
-                        iOS="16" />
+                        iOS="20" />
 
             <OnPlatform x:Key="DefaultPlaceholderColor"
                         x:TypeArguments="Color"         

--- a/SafeAuthenticator/Views/AppInfoPage.xaml
+++ b/SafeAuthenticator/Views/AppInfoPage.xaml
@@ -27,9 +27,12 @@
                 <Setter Property="FontSize" Value="{StaticResource SmallSize}" />
             </Style>
             <Style x:Key="RevokeButtonStyle" TargetType="Button">
-                <Setter Property="HeightRequest" Value="35" />
                 <Setter Property="Padding" Value="5" />
+                <Setter Property="HeightRequest" Value="35" />
                 <Setter Property="WidthRequest" Value="100" />
+                <Setter Property="FontAttributes" Value="Bold" />
+                <Setter Property="TextColor" Value="{StaticResource GreySmokeDarkColor}" />
+                <Setter Property="BackgroundColor" Value="{StaticResource GreySnowMediumColor}" />
             </Style>
         </ResourceDictionary>
     </ContentPage.Resources>


### PR DESCRIPTION
Fixes #67 
Use the following sizes for iOS
- Small: 14
- Medium: 16
- Large: 18
- ExtraLarge: 20

**Previous Sizes**
![size-old](https://user-images.githubusercontent.com/22762119/53087937-5ad22500-352e-11e9-9f19-ab17ee93018b.jpg)

**Updated Sizes**
![size-new](https://user-images.githubusercontent.com/22762119/53087970-71787c00-352e-11e9-82e4-a466926208ce.jpg)
