### PR TITLE
Update NativeProgressDialog on Android and iOS

### DIFF
--- a/SafeAuthenticator.Android/Helpers/AndroidNativeProgressDialogService.cs
+++ b/SafeAuthenticator.Android/Helpers/AndroidNativeProgressDialogService.cs
@@ -10,24 +10,23 @@ namespace SafeAuthenticator.Droid.Helpers
 {
     public class AndroidNativeProgressDialogService : INativeProgressDialogService
     {
-#pragma warning disable CS0618 // Type or member is obsolete
-        ProgressDialog progress = new ProgressDialog((Activity)Forms.Context);
-#pragma warning restore CS0618 // Type or member is obsolete
-
-        public void HideNativeDialog()
-        {
-            progress.Dismiss();
-        }
-
         public IDisposable ShowNativeDialog(string message, string title)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
+            ProgressDialog progress = new ProgressDialog((Activity)Forms.Context);
+#pragma warning restore CS0618 // Type or member is obsolete
+
             progress.Indeterminate = true;
             progress.SetProgressStyle(ProgressDialogStyle.Spinner);
             progress.SetTitle(title);
             progress.SetMessage(message);
             progress.SetCancelable(false);
             progress.Show();
-            return new DisposableAction(() => { progress.Dismiss(); });
+            return new DisposableAction(() =>
+            {
+                progress.Dismiss();
+                progress.Dispose();
+            });
         }
     }
 }

--- a/SafeAuthenticator.iOS/Helpers/AppleNativeProgressDialogService.cs
+++ b/SafeAuthenticator.iOS/Helpers/AppleNativeProgressDialogService.cs
@@ -10,11 +10,6 @@ namespace SafeAuthenticator.iOS.Helpers
 {
     class AppleNativeProgressDialogService : INativeProgressDialogService
     {
-        public void HideNativeDialog()
-        {
-            BTProgressHUD.Dismiss();
-        }
-
         public IDisposable ShowNativeDialog(string message, string title)
         {
             BTProgressHUD.Show(message, -1, ProgressHUD.MaskType.Black);

--- a/SafeAuthenticator/Controls/INativeProgressDialogService.cs
+++ b/SafeAuthenticator/Controls/INativeProgressDialogService.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace SafeAuthenticator.Controls
 {
     public interface INativeProgressDialogService
     {
         IDisposable ShowNativeDialog(string message, string title = null);
-
-        void HideNativeDialog();
     }
 }


### PR DESCRIPTION
Fixes #86 

When the back button is clicked the current activity is destroyed and when we reopen the app a new activity is created. But the `ProgressDialog` object is still referring to old activity, to fix this declare the `ProgressDialog` object as a local variable of `ShowNativeDialog` and dispose it at the end.
Also, the `Dismiss()` method is not required.