### PR TITLE
Add padding between Invitation token label and the text field

### DIFF
--- a/SafeAuthenticator.Android/Helpers/MaterialEntryRenderer.cs
+++ b/SafeAuthenticator.Android/Helpers/MaterialEntryRenderer.cs
@@ -95,7 +95,7 @@ namespace SafeAuthenticator.Droid.Helpers
                     EditText.ContentDescription = Element.AutomationId;
 
                 if (Element.IsUnderlineTransparent)
-                    Control.EditText.SetPadding(Control.PaddingLeft, Control.PaddingTop, Control.PaddingRight, 0);
+                    Control.EditText.SetPadding(Control.PaddingLeft, Control.EditText.PaddingTop / 2, Control.PaddingRight, Control.EditText.PaddingBottom / 2);
 
                 _defaultTextColor = EditText.TextColors;
 

--- a/SafeAuthenticator/Controls/CreateAcctPage/CreateAcctStep1.xaml
+++ b/SafeAuthenticator/Controls/CreateAcctPage/CreateAcctStep1.xaml
@@ -70,7 +70,9 @@
             <Image Source="clipboardPaste"
                    Style="{DynamicResource ImageStyle}"
                    Grid.Column="1"
-                   HorizontalOptions="End">
+                   HorizontalOptions="End"
+                   VerticalOptions="End"
+                   Margin="0,0,0,5">
                 <Image.GestureRecognizers>
                     <TapGestureRecognizer NumberOfTapsRequired="1"
                                           Command="{Binding ClipboardPasteCommand}" />

--- a/SafeAuthenticator/Views/TutorialPage.xaml
+++ b/SafeAuthenticator/Views/TutorialPage.xaml
@@ -49,8 +49,8 @@
                                        HorizontalOptions="CenterAndExpand"
                                        VerticalOptions="EndAndExpand"/>
 
-                                <Label HorizontalOptions="CenterAndExpand"
-                                       Style="{DynamicResource TitleStyle}"
+                                <Label Style="{DynamicResource TitleStyle}"
+                                       HorizontalTextAlignment="Center"
                                        Text="Securely connect to the SAFE Network"
                                        Margin="0, 40, 0, 0"
                                        VerticalOptions="End"/>


### PR DESCRIPTION
fixes#84

- Add the padding for the `Control.EditText.SetPadding()` in top and bottom.
- Since the padding in Control.EditText.PaddingTop is large, divided it by 2.

<img src="https://user-images.githubusercontent.com/45584218/53152026-89a5d500-35da-11e9-8cf4-dcff2a575d73.png" height="500" alt="screenshot_1550735005">

