### PR TITLE
Provide additional information for auto-reconnect

### DIFF
--- a/SafeAuthenticator/Helpers/Constants.cs
+++ b/SafeAuthenticator/Helpers/Constants.cs
@@ -15,5 +15,9 @@
         internal static readonly string None = "None";
         internal static readonly string Error = "Error";
         internal static readonly string Loading = "Loading";
+
+        // Dialogs
+        internal static readonly string AutoReconnectInfoDialog = "Enable this feature to automatically reconnect to the network." +
+            "Your credentials will be securely stored on your device.Logging out will clear the credentials from memory.";
     }
 }

--- a/SafeAuthenticator/Services/AuthService.cs
+++ b/SafeAuthenticator/Services/AuthService.cs
@@ -188,7 +188,7 @@ namespace SafeAuthenticator.Services
                 if (decodedType == typeof(IpcReqError))
                 {
                     var error = decodeResult as IpcReqError;
-                    await Application.Current.MainPage.DisplayAlert("Auth Request", $"Error: {error?.Description}", "Ok");
+                    await Application.Current.MainPage.DisplayAlert("Auth Request", $"Error: {error?.Description}", "OK");
                 }
                 else
                 {

--- a/SafeAuthenticator/ViewModels/SettingsViewModel.cs
+++ b/SafeAuthenticator/ViewModels/SettingsViewModel.cs
@@ -39,10 +39,21 @@ namespace SafeAuthenticator.ViewModels
                 if (Authenticator.AuthReconnect != value)
                 {
                     Authenticator.AuthReconnect = value;
+                    if (AuthReconnect)
+                        OnAutoReconnect();
                 }
 
                 OnPropertyChanged();
             }
+        }
+
+        private async void OnAutoReconnect()
+        {
+            AuthReconnect = await Application.Current.MainPage.DisplayAlert(
+            "Auto Reconnect",
+            Constants.AutoReconnectInfoDialog,
+            "OK",
+            "Cancel");
         }
 
         public SettingsViewModel()

--- a/SafeAuthenticator/Views/SettingsPage.xaml.cs
+++ b/SafeAuthenticator/Views/SettingsPage.xaml.cs
@@ -24,7 +24,7 @@ namespace SafeAuthenticator.Views
 
             AccountStatusImage.Clicked += (s, e) =>
             {
-                DisplayAlert("Account Status", "The number of store and modify operations completed on this account.", "ok");
+                DisplayAlert("Account Status", "The number of store and modify operations completed on this account.", "OK");
             };
 
             MessagingCenter.Subscribe<SettingsViewModel>(


### PR DESCRIPTION
Fixes #56 

When the auto-reconnect switch is toggled on display an alert with the following message `Enable this feature to automatically reconnect to the network. Your credentials will be securely stored on your device. Logging out will clear the credentials from memory.` Store the credentials in secure storage only if the user accepts this.