### PR TITLE
Authorization popup height not consistent

### DIFF
--- a/SafeAuthenticator/ViewModels/RequestDetailViewModel.cs
+++ b/SafeAuthenticator/ViewModels/RequestDetailViewModel.cs
@@ -53,6 +53,14 @@ namespace SafeAuthenticator.ViewModels
             set => SetProperty(ref _popupLayoutHeight, value);
         }
 
+        private bool _isAppDetailsVisible;
+
+        public bool IsAppDetailsVisible
+        {
+            get => _isAppDetailsVisible;
+            set => SetProperty(ref _isAppDetailsVisible, value);
+        }
+
         private string _errorMessage;
 
         public string ErrorMessage
@@ -70,6 +78,8 @@ namespace SafeAuthenticator.ViewModels
 
         public ICommand SendResponseCommand { get; }
 
+        public ICommand InfoButtonCommand { get; }
+
         public RequestDetailViewModel(string encodedUri, IpcReq req)
         {
             Containers = new ObservableRangeCollection<ContainerPermissionsModel>();
@@ -79,7 +89,10 @@ namespace SafeAuthenticator.ViewModels
             decodedRequest = req;
 
             PopupState = Constants.None;
+            IsAppDetailsVisible = false;
+
             SendResponseCommand = new Command<string>(OnSendResponse);
+            InfoButtonCommand = new Command(OnInfoButtonCommand);
 
             if (requestType == typeof(UnregisteredIpcReq))
             {
@@ -106,6 +119,15 @@ namespace SafeAuthenticator.ViewModels
                 SecondaryTitle = MData.Count > 0 ? "\nis requesting access to" : "\nis requesting access";
             }
             PopupLayoutHeight = (Containers.Count == 0 && MData.Count == 0) ? minPopupHeight : maxPopupHeight;
+        }
+
+        private void OnInfoButtonCommand()
+        {
+            IsAppDetailsVisible = !IsAppDetailsVisible;
+            if (IsAppDetailsVisible)
+                PopupLayoutHeight += 105;
+            else
+                PopupLayoutHeight -= 105;
         }
 
         private void ProcessAuthRequestData()
@@ -199,6 +221,9 @@ namespace SafeAuthenticator.ViewModels
             try
             {
                 var response = sender == "ALLOW" ? true : false;
+                if (IsAppDetailsVisible)
+                    IsAppDetailsVisible = !IsAppDetailsVisible;
+
                 PopupLayoutHeight = minPopupHeight;
                 PopupState = Constants.Loading;
                 var encodedRsp = await Authenticator.GetEncodedResponseAsync(decodedRequest, response);

--- a/SafeAuthenticator/Views/RequestDetailPage.xaml
+++ b/SafeAuthenticator/Views/RequestDetailPage.xaml
@@ -51,8 +51,7 @@
         <Frame Padding="0"
                BackgroundColor="{StaticResource WhiteColor}">
 
-            <StackLayout x:Name="PopupLayout" 
-                         Spacing="10"
+            <StackLayout Spacing="10"
                          Padding="16"
                          HeightRequest="{Binding PopupLayoutHeight}">
 
@@ -91,12 +90,12 @@
                                  x:Name="InfoIcon"
                                  HorizontalOptions="EndAndExpand"
                                  VerticalOptions="Start"
-                                 IsVisible="{Binding IsUnregisteredRequest, Converter={StaticResource InverseBoolean}}"/>
+                                 Command="{Binding InfoButtonCommand}"
+                                 IsVisible="{Binding IsUnregisteredRequest, Converter={StaticResource InverseBoolean}}" />
                 </Grid>
 
-                <StackLayout x:Name="AppDetailsStackLayout"
-                             VerticalOptions="Start" 
-                             IsVisible="False" 
+                <StackLayout VerticalOptions="Start" 
+                             IsVisible="{Binding IsAppDetailsVisible}" 
                              Margin="10,0">
                     <Label Style="{StaticResource H2Style}">
                         <Label.FormattedText>

--- a/SafeAuthenticator/Views/RequestDetailPage.xaml.cs
+++ b/SafeAuthenticator/Views/RequestDetailPage.xaml.cs
@@ -14,15 +14,6 @@ namespace SafeAuthenticator.Views
         {
             InitializeComponent();
 
-            InfoIcon.Clicked += (s, e) =>
-            {
-                AppDetailsStackLayout.IsVisible = !AppDetailsStackLayout.IsVisible;
-                if (AppDetailsStackLayout.IsVisible)
-                    PopupLayout.HeightRequest += 105;
-                else
-                    PopupLayout.HeightRequest -= 105;
-            };
-
             _viewModel = new RequestDetailViewModel(encodedUri, req);
             BindingContext = _viewModel;
         }


### PR DESCRIPTION
Fixes #98

Instead of using an `Onclick` event on the `InfoIcon` to display the `ID`, `Vendor` and resizing the popup, perform the same operation on the `ViewModel`. This is done to avoid altering a particular property in the code behind as well as in the ViewModel