### PR TITLE
Adjust padding, color and size (UI fix)

### DIFF
--- a/SafeAuthenticator/App.xaml
+++ b/SafeAuthenticator/App.xaml
@@ -13,6 +13,7 @@
             <Color x:Key="BlackColor">#000000</Color>
             <Color x:Key="WhiteColor">#ffffff</Color>
             <Color x:Key="RedColor">#d94a3d</Color>
+            <Color x:Key="GreySnowLightColor">#eeeeee</Color>
             <Color x:Key="GreySmokeLightColor">#c2c1c1</Color>
             <Color x:Key="GreySmokeMediumColor">#8b8b8b</Color>
             <Color x:Key="GreySmokeDarkColor">#555555</Color>

--- a/SafeAuthenticator/Controls/CreateAcctPage/CreateAcctStep2.xaml
+++ b/SafeAuthenticator/Controls/CreateAcctPage/CreateAcctStep2.xaml
@@ -12,24 +12,21 @@
     <Label Text="Your 'Account Secret' is private and should not be shared with anyone."
            Margin="0,0,0,20" />
 
-    <ContentView>
-        <StackLayout>
-            <controls:MaterialEntry x:Name="SecretEntry"
-                                    Placeholder="Account secret"
-                                    IsPassword="True"
-                                    Text="{Binding AcctSecret}"
-                                    ErrorDisplay="None"
-                                    Margin="0,50,0,0"
-                                    ReturnType="Next"
-                                    NextEntry="{Reference ConfirmSecretEntry}"/>
+    <controls:MaterialEntry x:Name="SecretEntry"
+                            Placeholder="Account secret"
+                            IsPassword="True"
+                            Text="{Binding AcctSecret}"
+                            ErrorDisplay="None"
+                            Margin="0,50,0,5"
+                            ReturnType="Next"
+                            NextEntry="{Reference ConfirmSecretEntry}"/>
 
-            <controls:MaterialEntry x:Name="ConfirmSecretEntry"
-                                    Placeholder="Confirm account secret"
-                                    IsPassword="True"
-                                    Text="{Binding ConfirmAcctSecret}"
-                                    ErrorText="{Binding AcctSecretErrorMsg}"
-                                    ReturnType="Done"
-                                    ReturnCommand="{Binding CarouselContinueCommand}" />
-        </StackLayout>
-    </ContentView>
+    <controls:MaterialEntry x:Name="ConfirmSecretEntry"
+                            Placeholder="Confirm account secret"
+                            IsPassword="True"
+                            Text="{Binding ConfirmAcctSecret}"
+                            ErrorText="{Binding AcctSecretErrorMsg}"
+                            ReturnType="Done"
+                            ReturnCommand="{Binding CarouselContinueCommand}" />
+    
 </StackLayout>

--- a/SafeAuthenticator/Controls/CreateAcctPage/CreateAcctStep3.xaml
+++ b/SafeAuthenticator/Controls/CreateAcctPage/CreateAcctStep3.xaml
@@ -16,7 +16,7 @@
                             IsPassword="True"
                             Text="{Binding AcctPassword}"
                             ErrorDisplay="None"
-                            Margin="0,50,0,0"
+                            Margin="0,50,0,5"
                             ReturnType="Next"
                             NextEntry="{Reference ConfirmPasswordEntry}" />
 

--- a/SafeAuthenticator/Views/LoginPage.xaml
+++ b/SafeAuthenticator/Views/LoginPage.xaml
@@ -52,7 +52,7 @@
                                             Placeholder="Account Secret"
                                             IsPassword="True"
                                             ErrorDisplay="None"
-                                            Margin="0,50,0,0"
+                                            Margin="0,50,0,5"
                                             Text="{Binding AccountSecret}"
                                             NextEntry="{Reference PasswordEntry}"
                                             ReturnType="Next"
@@ -71,7 +71,7 @@
 
                     <Button Text="LOGIN"
                             Command="{Binding LoginCommand}"
-                            Margin="0,15,0,0" />
+                            Margin="0,20,0,0" />
 
                     <Button Text="CREATE ACCOUNT"
                             HorizontalOptions="Center"

--- a/SafeAuthenticator/Views/RequestDetailPage.xaml
+++ b/SafeAuthenticator/Views/RequestDetailPage.xaml
@@ -53,10 +53,11 @@
 
             <StackLayout x:Name="PopupLayout" 
                          Spacing="10"
-                         Padding="16"
+                         Padding="0,16"
                          HeightRequest="{Binding PopupLayoutHeight}">
 
-                <Grid HorizontalOptions="FillAndExpand">
+                <Grid HorizontalOptions="FillAndExpand"
+                      Padding="16,0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
@@ -96,8 +97,9 @@
 
                 <StackLayout x:Name="AppDetailsStackLayout"
                              VerticalOptions="Start" 
-                             IsVisible="False" 
-                             Margin="10,0">
+                             IsVisible="False"
+                             Padding="16,10"
+                             BackgroundColor="{StaticResource GreySnowLightColor}">
                     <Label Style="{StaticResource H2Style}">
                         <Label.FormattedText>
                             <FormattedString>
@@ -115,7 +117,8 @@
                 </StackLayout>
 
                 <StackLayout IsVisible="False"
-                             VerticalOptions="CenterAndExpand">
+                             VerticalOptions="CenterAndExpand"
+                             Padding="16,0">
                     <StackLayout.Triggers>
                         <DataTrigger TargetType="StackLayout"
                                          Binding="{Binding PopupState}"
@@ -236,7 +239,8 @@
                 <StackLayout Orientation="Horizontal"
                              IsVisible="False"
                              HorizontalOptions="CenterAndExpand"
-                             VerticalOptions="CenterAndExpand">
+                             VerticalOptions="CenterAndExpand"
+                             Padding="16,0">
                     <StackLayout.Triggers>
                         <DataTrigger TargetType="StackLayout"
                                          Binding="{Binding PopupState}"
@@ -254,7 +258,7 @@
 
                 <Frame HasShadow="False"
                        CornerRadius="4"
-                       Padding="10"
+                       Padding="26,0"
                        BackgroundColor="{StaticResource RedLightColor}"
                        IsVisible="False"                        
                        VerticalOptions="CenterAndExpand">
@@ -274,7 +278,8 @@
 
                 <StackLayout Orientation="Horizontal"
                              VerticalOptions="End"
-                             IsVisible="False">
+                             IsVisible="False"
+                             Padding="16,0">
                     <StackLayout.Triggers>
                         <DataTrigger TargetType="StackLayout"
                                          Binding="{Binding PopupState}"
@@ -311,7 +316,8 @@
                         Style="{StaticResource ButtonStyle}"
                         BackgroundColor="Transparent" 
                         WidthRequest="50"
-                        IsVisible="False">
+                        IsVisible="False"
+                        Padding="16,0">
                     <Button.Triggers>
                         <DataTrigger TargetType="Button"
                                          Binding="{Binding PopupState}"


### PR DESCRIPTION
fixes#100

- Add padding between text fields in login page and create account page.
- Add a color to differentiate app info from permissions list in the RequestDetailPage.

**screenshots**
Android:
<img src="https://user-images.githubusercontent.com/45584218/53408806-78e3cd80-39e5-11e9-8fff-741bdf47829d.jpg" height="400" alt="screenshot_20190226-163833">

<img src="https://user-images.githubusercontent.com/45584218/53408807-797c6400-39e5-11e9-85ff-de8bbd5a48cb.jpg" height="400" alt="screenshot_20190226-163846">


<img src="https://user-images.githubusercontent.com/45584218/53408307-2c4bc280-39e4-11e9-8cf3-d3ce25afd288.jpg" height="400" alt="screenshot_20190226-162344">

iOS
<img src="https://user-images.githubusercontent.com/45584218/53408885-a92b6c00-39e5-11e9-9ec6-c288527f3b83.PNG" height="400" alt="img_3923">

<img src="https://user-images.githubusercontent.com/45584218/53409197-6027e780-39e6-11e9-9328-52a2a9d4803d.PNG" height="400" alt="img_3924">

<img src="https://user-images.githubusercontent.com/45584218/53408485-8cdaff80-39e4-11e9-9082-7f52f2193b17.PNG" height="400" alt="img_3922">
