### PR TITLE
Update the popup displayed when authorizing apps before login

### DIFF
--- a/SafeAuthenticator/App.xaml.cs
+++ b/SafeAuthenticator/App.xaml.cs
@@ -27,11 +27,13 @@ namespace SafeAuthenticator
 
             MessagingCenter.Subscribe<AuthService>(this, MessengerConstants.ResetAppViews, async _ => { await ResetViews(); });
             Current.MainPage = new NavigationPage(NewStartupPage());
-            MessagingCenter.Subscribe<AuthService>(this, MessengerConstants.NavHomePage, async _ =>
+            MessagingCenter.Subscribe<AuthService>(this, MessengerConstants.NavPreviousPage, async _ =>
             {
                 var navigationStackSize = Current.MainPage.Navigation.NavigationStack.Count - 1;
                 var topNavigationStackPageType = Current.MainPage.Navigation.NavigationStack[navigationStackSize].GetType();
-                if (topNavigationStackPageType == typeof(SettingsPage) || topNavigationStackPageType == typeof(AppInfoPage))
+                if (topNavigationStackPageType == typeof(SettingsPage) ||
+                    topNavigationStackPageType == typeof(AppInfoPage) ||
+                    topNavigationStackPageType == typeof(CreateAcctPage))
                 {
                     await Current.MainPage.Navigation.PopAsync();
                 }

--- a/SafeAuthenticator/Helpers/MessengerConstants.cs
+++ b/SafeAuthenticator/Helpers/MessengerConstants.cs
@@ -7,6 +7,7 @@
         internal static readonly string NavHomePage = "NavHomePage";
         internal static readonly string NavLoginPage = "NavLoginPage";
         internal static readonly string NavSettingsPage = "NavSettingsPage";
+        internal static readonly string NavPreviousPage = "NavPreviousPage";
         internal static readonly string ResetAppViews = "ResetAppViews";
         internal static readonly string RefreshHomePage = "RefreshHomePage";
     }

--- a/SafeAuthenticator/Services/AuthService.cs
+++ b/SafeAuthenticator/Services/AuthService.cs
@@ -174,7 +174,15 @@ namespace SafeAuthenticator.Services
                     if (await HandleUnregisteredAppRequest(encodedUri))
                         return;
                     AuthenticationReq = encodedUri;
-                    await Application.Current.MainPage.DisplayAlert("Login", "An application is requesting access, login to view details", "OK");
+                    var response = await Application.Current.MainPage.DisplayAlert(
+                        "Login Required",
+                        "An application is requesting access, login to authorise",
+                        "Login",
+                        "Cancel");
+                    if (response)
+                    {
+                        MessagingCenter.Send(this, MessengerConstants.NavPreviousPage);
+                    }
                     return;
                 }
 
@@ -192,7 +200,7 @@ namespace SafeAuthenticator.Services
                 }
                 else
                 {
-                    MessagingCenter.Send(this, MessengerConstants.NavHomePage);
+                    MessagingCenter.Send(this, MessengerConstants.NavPreviousPage);
                     var requestPage = new RequestDetailPage(encodedUri, decodeResult);
                     await Application.Current.MainPage.Navigation.PushPopupAsync(requestPage);
                 }

--- a/SafeAuthenticator/Views/LoginPage.xaml.cs
+++ b/SafeAuthenticator/Views/LoginPage.xaml.cs
@@ -39,8 +39,6 @@ namespace SafeAuthenticator.Views
                         return;
                     }
 
-                    Debug.WriteLine("LoginPage -> HomePage");
-
                     Navigation.InsertPageBefore(new HomePage(), this);
                     await Navigation.PopAsync();
                 });
@@ -56,7 +54,6 @@ namespace SafeAuthenticator.Views
                         return;
                     }
 
-                    Debug.WriteLine("LoginPage -> CreateAcctPage");
                     NavigationPage.SetBackButtonTitle(this, "Login");
                     await Navigation.PushAsync(new CreateAcctPage());
                 });


### PR DESCRIPTION
Fixes #99 

If authorisation is sent to the authenticator before login we display a popup, have two options on the popup `login` and `Cancel`. If the user is present on the `CreateAcctPage`  redirect them to the login page