### PR TITLE
Texual change in CreateAccount/Login Page and Pop-ups  

### DIFF
--- a/SafeAuthenticator/Controls/CreateAcctPage/CreateAcctStep2.xaml
+++ b/SafeAuthenticator/Controls/CreateAcctPage/CreateAcctStep2.xaml
@@ -3,33 +3,29 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:SafeAuthenticator.Controls"
              x:Class="SafeAuthenticator.Controls.CreateAcctStep2"
-             Spacing="15"
              Padding="25,0">
     
     <Label Text="Account Secret"
            Style="{DynamicResource TitleStyle}"/>
 
     <Label Text="Your 'Account Secret' is private and should not be shared with anyone."
-           Margin="0,0,0,20" />
+           Margin="0,10,0,20" />
 
-    <ContentView>
-        <StackLayout>
-            <controls:MaterialEntry x:Name="SecretEntry"
-                                    Placeholder="Account secret"
-                                    IsPassword="True"
-                                    Text="{Binding AcctSecret}"
-                                    ErrorDisplay="None"
-                                    Margin="0,50,0,0"
-                                    ReturnType="Next"
-                                    NextEntry="{Reference ConfirmSecretEntry}"/>
+    <controls:MaterialEntry x:Name="SecretEntry"
+                            Placeholder="Account secret"
+                            IsPassword="True"
+                            Text="{Binding AcctSecret}"
+                            ErrorText="{Binding AcctSecretStrengthErrorMsg}"
+                            Margin="0,30,0,0"
+                            ReturnType="Next"
+                            NextEntry="{Reference ConfirmSecretEntry}"/>
 
-            <controls:MaterialEntry x:Name="ConfirmSecretEntry"
-                                    Placeholder="Confirm account secret"
-                                    IsPassword="True"
-                                    Text="{Binding ConfirmAcctSecret}"
-                                    ErrorText="{Binding AcctSecretErrorMsg}"
-                                    ReturnType="Done"
-                                    ReturnCommand="{Binding CarouselContinueCommand}" />
-        </StackLayout>
-    </ContentView>
+    <controls:MaterialEntry x:Name="ConfirmSecretEntry"
+                            Placeholder="Confirm account secret"
+                            IsPassword="True"
+                            Text="{Binding ConfirmAcctSecret}"
+                            ErrorText="{Binding AcctSecretErrorMsg}"
+                            ReturnType="Done"
+                            ReturnCommand="{Binding CarouselContinueCommand}" />
+        
 </StackLayout>

--- a/SafeAuthenticator/Controls/CreateAcctPage/CreateAcctStep3.xaml
+++ b/SafeAuthenticator/Controls/CreateAcctPage/CreateAcctStep3.xaml
@@ -3,20 +3,20 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:SafeAuthenticator.Controls"
              x:Class="SafeAuthenticator.Controls.CreateAcctStep3"
-             Spacing="15"
              Padding="25,0">
+    
     <Label Text="Account Password"
            Style="{DynamicResource TitleStyle}" />
 
     <Label Text="Your 'Account Password' is never sent to the network, it will not leave your device."
-           Margin="0,0,0,20" />
+           Margin="0,10,0,20" />
 
     <controls:MaterialEntry x:Name="PasswordEntry"
                             Placeholder="Account password"
                             IsPassword="True"
                             Text="{Binding AcctPassword}"
-                            ErrorDisplay="None"
-                            Margin="0,50,0,0"
+                            ErrorText="{Binding AcctPasswordStrengthErrorMsg}"
+                            Margin="0,30,0,0"
                             ReturnType="Next"
                             NextEntry="{Reference ConfirmPasswordEntry}" />
 

--- a/SafeAuthenticator/Helpers/Constants.cs
+++ b/SafeAuthenticator/Helpers/Constants.cs
@@ -18,6 +18,6 @@
 
         // Dialogs
         internal static readonly string AutoReconnectInfoDialog = "Enable this feature to automatically reconnect to the network." +
-            "Your credentials will be securely stored on your device.Logging out will clear the credentials from memory.";
+            " Your credentials will be securely stored on your device. Logging out will clear the credentials from memory.";
     }
 }

--- a/SafeAuthenticator/ViewModels/AppInfoViewModel.cs
+++ b/SafeAuthenticator/ViewModels/AppInfoViewModel.cs
@@ -32,7 +32,7 @@ namespace SafeAuthenticator.ViewModels
         private async void OnRevokeAppCommand()
         {
             if (await Application.Current.MainPage.DisplayAlert(
-                "Revoke Access",
+                "Revoking application",
                 $"Are you sure you want to revoke access for {_appModelInfo.AppName}?",
                 "Revoke",
                 "Cancel"))
@@ -43,7 +43,7 @@ namespace SafeAuthenticator.ViewModels
                     {
                         throw new Exception("No internet connection");
                     }
-                    using (NativeProgressDialog.ShowNativeDialog("Revoking app access"))
+                    using (NativeProgressDialog.ShowNativeDialog("Revoking application"))
                     {
                         await Authenticator.RevokeAppAsync(_appModelInfo.AppId);
                         MessagingCenter.Send(this, MessengerConstants.NavHomePage);
@@ -57,7 +57,7 @@ namespace SafeAuthenticator.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await Application.Current.MainPage.DisplayAlert("Error", $"Revoke app Failed: {ex.Message}", "OK");
+                    await Application.Current.MainPage.DisplayAlert("Error", $"Revoke Application Failed: {ex.Message}", "OK");
                 }
             }
         }

--- a/SafeAuthenticator/ViewModels/AppInfoViewModel.cs
+++ b/SafeAuthenticator/ViewModels/AppInfoViewModel.cs
@@ -32,7 +32,7 @@ namespace SafeAuthenticator.ViewModels
         private async void OnRevokeAppCommand()
         {
             if (await Application.Current.MainPage.DisplayAlert(
-                "Revoking application",
+                "Revoke application",
                 $"Are you sure you want to revoke access for {_appModelInfo.AppName}?",
                 "Revoke",
                 "Cancel"))

--- a/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
+++ b/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
@@ -159,7 +159,7 @@ namespace SafeAuthenticator.ViewModels
             });
             ClipboardPasteCommand = new Command(async () =>
             {
-                string invitation_temp = await Clipboard.GetTextAsync();
+                string invitation_temp = (await Clipboard.GetTextAsync()).Trim();
                 if (!string.IsNullOrWhiteSpace(invitation_temp))
                     Invitation = invitation_temp;
             });

--- a/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
+++ b/SafeAuthenticator/ViewModels/CreateAcctViewModel.cs
@@ -98,12 +98,28 @@ namespace SafeAuthenticator.ViewModels
             set => SetProperty(ref _acctSecretErrorMsg, value);
         }
 
+        private string _acctSecretStrengthErrorMsg;
+
+        public string AcctSecretStrengthErrorMsg
+        {
+            get => _acctSecretStrengthErrorMsg;
+            set => SetProperty(ref _acctSecretStrengthErrorMsg, value);
+        }
+
         private string _acctPasswordErrorMsg;
 
         public string AcctPasswordErrorMsg
         {
             get => _acctPasswordErrorMsg;
             set => SetProperty(ref _acctPasswordErrorMsg, value);
+        }
+
+        private string _acctPasswordStrengthErrorMsg;
+
+        public string AcctPasswordStrengthErrorMsg
+        {
+            get => _acctPasswordStrengthErrorMsg;
+            set => SetProperty(ref _acctPasswordStrengthErrorMsg, value);
         }
 
         public ICommand CarouselPageChangeCommand { get; }
@@ -143,7 +159,9 @@ namespace SafeAuthenticator.ViewModels
             });
             ClipboardPasteCommand = new Command(async () =>
             {
-                Invitation = await Clipboard.GetTextAsync();
+                string invitation_temp = await Clipboard.GetTextAsync();
+                if (!string.IsNullOrWhiteSpace(invitation_temp))
+                    Invitation = invitation_temp;
             });
         }
 
@@ -158,6 +176,7 @@ namespace SafeAuthenticator.ViewModels
                         if (AcctSecret == ConfirmAcctSecret)
                         {
                             AcctSecretErrorMsg = string.Empty;
+                            AcctSecretStrengthErrorMsg = string.Empty;
                         }
                         return !string.IsNullOrWhiteSpace(AcctSecret) && !string.IsNullOrWhiteSpace(ConfirmAcctSecret);
                     }
@@ -166,6 +185,7 @@ namespace SafeAuthenticator.ViewModels
                         if (AcctPassword == ConfirmAcctPassword)
                         {
                             AcctPasswordErrorMsg = string.Empty;
+                            AcctPasswordStrengthErrorMsg = string.Empty;
                         }
                         return !string.IsNullOrWhiteSpace(AcctPassword) && !string.IsNullOrWhiteSpace(ConfirmAcctPassword);
                     }
@@ -194,10 +214,10 @@ namespace SafeAuthenticator.ViewModels
                             _locationStrength = Utilities.StrengthChecker(AcctSecret);
                             if (_locationStrength.Guesses < Constants.AccStrengthWeak)
                             {
-                                AcctSecretErrorMsg = "Secret needs to be stronger";
+                                AcctSecretStrengthErrorMsg = "Secret needs to be stronger";
                                 throw new InvalidOperationException();
                             }
-                            AcctSecretErrorMsg = string.Empty;
+                            AcctSecretStrengthErrorMsg = string.Empty;
                         });
                     }
                 }
@@ -245,10 +265,10 @@ namespace SafeAuthenticator.ViewModels
                     _passwordStrength = Utilities.StrengthChecker(AcctPassword);
                     if (_passwordStrength.Guesses < Constants.AccStrengthSomeWhatSecure)
                     {
-                        AcctPasswordErrorMsg = "Password needs to be stronger";
+                        AcctPasswordStrengthErrorMsg = "Password needs to be stronger";
                         throw new InvalidOperationException();
                     }
-                    AcctPasswordErrorMsg = string.Empty;
+                    AcctPasswordStrengthErrorMsg = string.Empty;
                 });
 
                 await Authenticator.CreateAccountAsync(AcctSecret, AcctPassword, Invitation);

--- a/SafeAuthenticator/Views/CreateAcctPage.xaml
+++ b/SafeAuthenticator/Views/CreateAcctPage.xaml
@@ -23,7 +23,7 @@
 
     <ContentPage.Content>
         <ScrollView>
-            <StackLayout Spacing="10">
+            <StackLayout >
                 <cv:CarouselViewControl
                     ShowArrows="False"
                     ShowIndicators="False"
@@ -50,7 +50,7 @@
 
                 <Button Text="CONTINUE"
                     Command="{Binding CarouselContinueCommand}"
-                    Margin="25,0"/>
+                    Margin="25,0,25,10"/>
 
                 <Button Text="BACK"
                     HorizontalOptions="Center"

--- a/SafeAuthenticator/Views/LoginPage.xaml
+++ b/SafeAuthenticator/Views/LoginPage.xaml
@@ -36,8 +36,7 @@
                                     Padding="25"
                                     IsScrollEnabled="False">
             <StackLayout>
-                <StackLayout VerticalOptions="CenterAndExpand"
-                             Spacing="10">
+                <StackLayout VerticalOptions="CenterAndExpand">
 
                     <Image Source="authLogo"
                            Style="{StaticResource ImageStyle}"
@@ -46,15 +45,15 @@
                     <Label Text="SAFE Authenticator"
                            Style="{StaticResource TitleStyle}"
                            HorizontalOptions="Center"
-                           Margin="0,10,0,0" />
+                           Margin="0,20,0,10" />
 
                     <controls:MaterialEntry x:Name="SecretEntry"
                                             Placeholder="Account Secret"
                                             IsPassword="True"
-                                            ErrorDisplay="None"
-                                            Margin="0,50,0,0"
+                                            Margin="0,30,0,10"
                                             Text="{Binding AccountSecret}"
                                             NextEntry="{Reference PasswordEntry}"
+                                            ErrorDisplay="None"
                                             ReturnType="Next"
                                             Focused="CustomEntryFocused"
                                             Unfocused="CustomEntryUnfocused"/>
@@ -62,7 +61,6 @@
                     <controls:MaterialEntry x:Name="PasswordEntry"
                                             Placeholder="Account Password" 
                                             IsPassword="True"
-                                            ErrorDisplay="None"
                                             Text="{Binding AccountPassword}"
                                             ReturnType="Done"
                                             ReturnCommand="{Binding LoginCommand}"

--- a/SafeAuthenticator/Views/RequestDetailPage.xaml
+++ b/SafeAuthenticator/Views/RequestDetailPage.xaml
@@ -102,7 +102,7 @@
                        Text="Authorisation request" />
 
                 <StackLayout VerticalOptions="Start" 
-                             IsVisible="{Binding IsAppDetailsVisible}" 
+                             IsVisible="{Binding IsAppDetailsVisible}"
                              Padding="16,10"
                              BackgroundColor="{StaticResource GreySnowLightColor}">
                     <Label Style="{StaticResource H2Style}">

--- a/SafeAuthenticator/Views/RequestDetailPage.xaml
+++ b/SafeAuthenticator/Views/RequestDetailPage.xaml
@@ -94,6 +94,12 @@
                                  IsVisible="{Binding IsUnregisteredRequest, Converter={StaticResource InverseBoolean}}"/>
                 </Grid>
 
+                <Label HorizontalTextAlignment="Center"
+                       VerticalOptions="Center"
+                       Style="{StaticResource H1Style}"
+                       IsVisible="{Binding IsUnregisteredRequest}"
+                       Text="Authorisation request" />
+
                 <StackLayout x:Name="AppDetailsStackLayout"
                              VerticalOptions="Start" 
                              IsVisible="False" 
@@ -247,7 +253,7 @@
 
                     <ActivityIndicator IsRunning="True"/>
                     
-                    <Label Text="Authenticating Application..."
+                    <Label Text="Please wait..."
                            FontSize="{StaticResource LargeSize}"
                            VerticalTextAlignment="Center"/>
                 </StackLayout>


### PR DESCRIPTION
fixes#101 #102 #103

- Textual change for the pop-ups
- Check clipboard string in the invitation token entry using `IsNullOrWhiteSpace` before pasting it.
- Show the Secret/Password strength error message under Secret/Password field 
    - create a bindable property `AcctSecretStrengthErrorMsg` for Secret
    - create a bindable property `AcctPasswordStrengthErrorMsg` for Password
- Adjust padding in createaccountpage and loginpage 
