### PR TITLE
fix/SafeAuth: bug fixes

### DIFF
--- a/SafeAuthenticator.Android/Helpers/AppHandler.cs
+++ b/SafeAuthenticator.Android/Helpers/AppHandler.cs
@@ -17,6 +17,7 @@ namespace SafeAuthenticator.Droid.Helpers
             {
                 var parsedUri = Android.Net.Uri.Parse(uri);
                 var intent = new Intent(Intent.ActionView, parsedUri);
+                intent.AddFlags(ActivityFlags.NewTask);
                 Activity.Current.AppContext.StartActivity(intent);
                 result = true;
             }

--- a/SafeAuthenticator.iOS/Helpers/AppHandler.cs
+++ b/SafeAuthenticator.iOS/Helpers/AppHandler.cs
@@ -11,11 +11,6 @@ namespace SafeAuthenticator.iOS.Helpers
     {
         public Task<bool> LaunchApp(string uri)
         {
-            var canOpen = UIApplication.SharedApplication.CanOpenUrl(new NSUrl(uri));
-
-            if (!canOpen)
-                return Task.FromResult(false);
-
             return Task.FromResult(UIApplication.SharedApplication.OpenUrl(new NSUrl(uri)));
         }
     }

--- a/SafeAuthenticator/Helpers/Utilities.cs
+++ b/SafeAuthenticator/Helpers/Utilities.cs
@@ -148,7 +148,7 @@ namespace SafeAuthenticator.Helpers
                 case Constants.PublicFormattedContainer:
                     return formattedText;
                 default:
-                    throw new Exception(string.Format(Constants.InvalidContainer, formattedText));
+                    throw new Exception(string.Format(Constants.InvalidContainer, containerName));
             }
         }
 


### PR DESCRIPTION
Bug Fixes:
- The [OpenUrl](https://docs.microsoft.com/en-us/dotnet/api/uikit.uiapplication.openurl?view=xamarin-ios-sdk-12) API returns true if the URL was successfully opened else return false. 
- Incorrect container name displayed when an invalid container is requested.
- Add intent flag to start an activity from a non-activity context