### PR TITLE
chore/bindings: update to use safe_authenticator v0.9.1 libs

### DIFF
--- a/CakeScripts/IOSTest.cake
+++ b/CakeScripts/IOSTest.cake
@@ -5,7 +5,7 @@
 #addin "Cake.Powershell"
 
 var IOS_SIM_NAME = EnvironmentVariable("IOS_SIM_NAME") ?? "iPhone X";
-var IOS_SIM_RUNTIME = EnvironmentVariable("IOS_SIM_RUNTIME") ?? "iOS 12.0";
+var IOS_SIM_RUNTIME = EnvironmentVariable("IOS_SIM_RUNTIME") ?? "iOS 12.1";
 var IOS_TEST_PROJ = "../Tests/SafeAuth.Tests.IOS/SafeAuth.Tests.IOS.csproj";
 var IOS_BUNDLE_ID = "net.maidsafe.SafeAuthenticatorTests";
 var IOS_IPA_PATH = "../Tests/SafeAuth.Tests.IOS/bin/iPhoneSimulator/Release/NunitTests.app";

--- a/CakeScripts/NativeLibs.cake
+++ b/CakeScripts/NativeLibs.cake
@@ -30,7 +30,7 @@ enum Environment
 // --------------------------------------------------------------------------------
 // Native lib directory
 // --------------------------------------------------------------------------------
-var TAG = "0.9.0";
+var TAG = "0.9.1";
 var nativeLibDirectory = Directory(string.Concat(System.IO.Path.GetTempPath(), "nativeauthlibs"));
 var androidLibDirectory = Directory("../SafeAuthenticator.Android/lib/");
 var iosLibDirectory = Directory("../SafeAuthenticator.iOS/Native References/");

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The release process is triggered by the maintainers of the package once it is me
 
 ## Useful resources
 
-* [Using High-Performance C++ Libraries in Cross-Platform Xamarin.Forms Applications](https://blog.xamarin.com/using-c-libraries-xamarin-forms-apps/)
+* [Using High-Performance C++ Libraries in Cross-Platform Xamarin.Forms Applications](https://devblogs.microsoft.com/xamarin/using-c-libraries-xamarin-forms-apps/)
 * [Native interoperability](https://docs.microsoft.com/en-us/dotnet/standard/native-interop/)
 * [Interop with Native Libraries](https://www.mono-project.com/docs/advanced/pinvoke/)
 * [Using Native Libraries in Xamarin.Android](https://docs.microsoft.com/en-us/xamarin/android/platform/native-libraries)


### PR DESCRIPTION
- Updated README
- Updated Simulator to use iOS 12.1