### PR TITLE
fix/iOS: Update iOS build from iPhone/iPad to universal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ tools/**
 *.GhostDoc.xml
 .vs/
 .vscode
+.mfractor
 
 # ignore Xamarin.Android Resource.Designer.cs files
 **/*.Droid/**/[Rr]esource.[Dd]esigner.cs

--- a/SafeAuthenticator.iOS/Info.plist
+++ b/SafeAuthenticator.iOS/Info.plist
@@ -17,6 +17,7 @@
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>
+		<integer>2</integer>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>


### PR DESCRIPTION
**Change:**
Updated iOS build to target universal devices previously it was set to iPhone/iPad and was not using full device screen. This PR will fix that, though some changes to the UI may be needed which will be addressed in a separate PR.

**Other Changes:**
Updated `gitignore` file to ignore mfractor (VS extension) files.

**Before:**

![Simulator Screen Shot - iPad Pro (12 9-inch) (3rd generation) - 2019-08-19 at 08 24 02](https://user-images.githubusercontent.com/9795917/63246547-900ec400-c280-11e9-85ad-1bc03a2bde1e.png)

**After:**

![Simulator Screen Shot - iPad Pro (12 9-inch) (3rd generation) - 2019-08-19 at 08 23 37](https://user-images.githubusercontent.com/9795917/63246548-900ec400-c280-11e9-99e4-52dd41b13327.png)